### PR TITLE
docs: sync README and references with evolution-loop and plugin changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,13 @@ so a partial addition fails loudly.
 ## A note on eval specs
 
 Generated skills bundle `run_evals.py` (from `scripts/run_evals_template.py`),
-which executes spec-defined command checks via the shell. Eval specs are
-trusted input — only run evals from specs you or your team wrote.
+which executes spec-defined command checks via the shell, compares rollout
+output against promoted baselines (regression gate), holds out `"split": "test"`
+cases from optimization, and — with `--judge` — grades `llm-judge` criteria via
+a judge pinned in the spec (with a known-bad canary that must fail). Skills also
+bundle `evolve.py` (from `scripts/evolve_template.py`) and plugin manifests
+(from `scripts/claude-plugin-template/`). Eval specs are trusted input — only
+run evals from specs you or your team wrote.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ totals, and email a PDF sales report.
 ▸ Phase 2  Design+evals   ▸ Phase 5  Build · validate · security-scan
 ▸ Phase 3  Architecture
 
-✓ weekly-crm-report-skill  (12 files, evals, installer)
+✓ weekly-crm-report-skill  (23 files: evals, installer, plugin manifests, evolve loop)
   installed on Claude Code, Cursor, Gemini CLI
 
 Use it:  /weekly-crm-report-skill data/crm-export.csv
@@ -163,9 +163,11 @@ The generated skill includes a cross-platform installer (`install.sh`) that auto
 sales-report-skill/
 ├── SKILL.md          # Skill definition (activates with /sales-report-skill)
 ├── AGENTS.md         # Companion file (read by many tools for cross-tool reach)
-├── scripts/          # Functional Python code
+├── .claude-plugin/   # plugin.json + marketplace.json (/plugin install path)
+├── scripts/          # Functional Python code + run_evals.py + evolve.py (self-maintenance)
 ├── references/       # Detailed documentation
 ├── assets/           # Templates, configs
+├── evals/            # Bundled eval spec + golden cases (the skill's own metric)
 ├── install.sh        # Cross-platform installer (17 platforms, format adapters, --all flag)
 └── README.md         # Installation instructions
 ```
@@ -178,7 +180,7 @@ Your team installs it the same way — one `git clone` to their tool's path — 
 
 **v6 — Artifacts.** Skills can emit **interactive React artifacts** in Claude Code (and Claude.ai). When output is visualizable — time series, comparisons, KPIs, tables — Phase 2 inlines one of four bundled React templates plus the artifact protocol into the generated SKILL.md; you write no React. In hosts that don't render artifacts (Cursor, Cline, Codex CLI, Gemini CLI) the source appears as fenced code and the markdown analysis is unchanged — honest degradation. Suppress with `--no-artifact`; force a template with `--artifact <line-chart|bar-chart|kpi-cards|data-table>`. ([design notes](docs/superpowers/specs/2026-05-27-agent-skill-creator-v5-artifacts-first-design.md))
 
-**Every skill ships its own metric.** Each generated skill carries an **eval spec** (`evals/<name>.eval.md`) plus a `scripts/run_evals.py` runner. In Phase 2 the creator derives 3–6 **binary** checks and ≥3 golden cases (seeded from your own files); you give a one-word thumbs-up. It's an instant regression test — `python3 scripts/run_evals.py` exits non-zero on failure, so it drops into CI. With a declared `run` command, `run_evals.py --rollout` executes the skill on each golden input and scores the real output (`--rollout --promote` captures the first passing baseline). The spec is consumable by `autoresearch-universal` for optimization with no reformatting. *Honest limits:* `--rollout` is opt-in (it runs arbitrary skill code), and `llm-judge` checks print as a checklist rather than being auto-graded. On by default; skip with `--no-eval`.
+**Every skill ships its own metric.** Each generated skill carries an **eval spec** (`evals/<name>.eval.md`) plus a `scripts/run_evals.py` runner. In Phase 2 the creator derives 3–6 **binary** checks and ≥3 golden cases (seeded from your own files); you give a one-word thumbs-up. It's an instant regression test — `python3 scripts/run_evals.py` exits non-zero on failure, so it drops into CI. With a declared `run` command, `run_evals.py --rollout` executes the skill on each golden input, scores the real output, and **compares it against the promoted baseline** — divergence that slips past every command check still fails as a regression (`--rollout --promote` captures the first passing baseline; per-case `compare_ignore` handles volatile fields like timestamps). `--judge` grades `llm-judge` criteria with a judge **pinned in the spec** (model + temperature), and a known-bad canary must fail every criterion or the judge run is invalid. One golden case per skill is a `"split": "test"` **holdout** — skipped by default, scored only with `--include-holdout`, never fed to an optimization loop. Any failing run appends its raw evidence to the skill's `EVOLUTION.md`. The spec is consumable by `autoresearch-universal` for optimization with no reformatting. *Honest limits:* `--rollout` is opt-in (it runs arbitrary skill code), and `--judge` needs `ANTHROPIC_API_KEY`. On by default; skip with `--no-eval`.
 
 ---
 
@@ -194,7 +196,7 @@ BUILD         Structure directory → write code and docs → craft activation k
 VERIFY        Spec validation → security scan → block delivery if either fails
 ```
 
-Every skill is automatically validated (correct structure, naming, metadata) and security-scanned (no hardcoded keys, no credential exposure, no injection risks) before delivery. Skills that fail these checks are blocked.
+Every skill is automatically validated (correct structure, naming, metadata) and security-scanned before delivery: hardcoded keys, credential exposure, dangerous code patterns, **prompt injection in the instruction body itself** (override phrases, concealment/exfiltration directives, hidden unicode, encoded blobs), and undeclared network endpoints in scripts. Skills that fail these checks are blocked.
 
 ---
 
@@ -473,7 +475,7 @@ Every skill goes through automated checks before delivery and on every publish:
 | Gate | What It Checks |
 |------|---------------|
 | **Spec Validation** | SKILL.md structure, frontmatter format, naming rules, file references |
-| **Security Scan** | No hardcoded API keys, no credentials, no injection patterns |
+| **Security Scan** | Hardcoded keys/credentials, dangerous code patterns, instruction-body prompt injection (override/concealment/exfiltration phrases, hidden unicode, encoded blobs), undeclared network endpoints |
 | **Staleness Check** | Review dates, dependency health, API schema drift |
 
 Run them independently anytime:
@@ -482,10 +484,10 @@ Run them independently anytime:
 python3 scripts/validate.py ./my-skill/
 python3 scripts/security_scan.py ./my-skill/
 python3 scripts/staleness_check.py ./my-skill/
-python3 scripts/staleness_check.py ./my-skill/ --check-deps --check-drift
+python3 scripts/staleness_check.py ./my-skill/ --check-deps --check-drift --record
 ```
 
-Skills that fail validation cannot be published. On publish, high-severity security issues block the skill (override with `--force`). On export, findings are reported but don't block by default — pass `--strict` to fail the export on any high-severity issue.
+Skills that fail validation cannot be published. On publish, high-severity security issues are a hard block — `--force` only overrides duplicate-version entries, never security findings. On export, findings are reported but don't block by default — pass `--strict` to fail the export on any high-severity issue.
 
 ---
 
@@ -493,7 +495,15 @@ Skills that fail validation cannot be published. On publish, high-severity secur
 
 Skills go stale. APIs change, compliance rules update, data sources move. A skill that worked six months ago may silently produce wrong results today. Staleness detection surfaces this before users hit it.
 
-Three layers, each opt-in:
+**Generated skills carry this tooling themselves.** Every skill ships `scripts/evolve.py` plus the staleness/dependency/drift modules, so from the skill's own root one command closes the maintenance loop — no creator repo needed:
+
+```bash
+python3 scripts/evolve.py           # staleness + deps + drift + eval rollout
+python3 scripts/evolve.py --judge   # also grade llm-judge criteria
+# Any failure appends its raw evidence to the skill's EVOLUTION.md
+```
+
+The creator-repo commands below work too (for skills built before the toolkit shipped, or ad-hoc checks). Three layers, each opt-in:
 
 **Review tracking** — Every skill can declare when it was last reviewed and how often it should be. The staleness checker compares these dates and flags overdue skills. Skills without explicit dates fall back to the last git commit date on SKILL.md.
 
@@ -573,6 +583,7 @@ python3 scripts/security_scan.py ./skill/ --json    # Machine-readable output
 python3 scripts/staleness_check.py ./skill/                      # Review staleness
 python3 scripts/staleness_check.py ./skill/ --check-deps         # + dependency health
 python3 scripts/staleness_check.py ./skill/ --check-drift        # + schema drift
+python3 scripts/staleness_check.py ./skill/ --record             # append findings to EVOLUTION.md
 python3 scripts/staleness_check.py ./skill/ --json               # Machine-readable output
 ```
 
@@ -649,19 +660,22 @@ agent-skill-creator/
   CHANGELOG.md                  # Version history
   LICENSE                       # MIT
   install.sh / install.ps1      # Self-installer for cloned repos (macOS/Linux, Windows)
+  .claude-plugin/               # plugin.json + marketplace.json (/plugin marketplace add)
   scripts/
     bootstrap.sh / .ps1 / .bat  # One-liner bootstrap (macOS/Linux, PowerShell, cmd)
     install-skill.sh / .ps1     # Universal skill installer
     install-template.sh / .ps1  # Template for generated skills' installers
     platforms.py                # Canonical 17-platform registry (single source of truth)
     validate.py                 # SKILL.md spec compliance checker
-    security_scan.py            # Secret / injection scanner
+    security_scan.py            # Secrets + code patterns + instruction-body injection + endpoint audit
     check_pipeline.py           # Verifies generated scripts compile + declare deps
     export_utils.py             # Cross-platform export (desktop / API packages)
     skill_registry.py           # Git-based team skill registry
     skill_document.py           # SKILL.md parser (shared by the tools above)
-    run_evals_template.py       # Eval runner bundled into generated skills
-    staleness_check.py          # Staleness: review dates, deps, schema drift
+    run_evals_template.py       # Eval runner bundled into generated skills (rollout, regression gate, judge, holdout)
+    evolve_template.py          # Self-maintenance loop bundled into generated skills (evolve.py)
+    claude-plugin-template/     # Plugin manifest templates bundled into generated skills
+    staleness_check.py          # Staleness: review dates, deps, schema drift (--record → EVOLUTION.md)
     dependency_health.py        # API dependency reachability check
     schema_drift.py             # API schema drift detection
     review_staleness.py         # Review-date staleness logic

--- a/SKILL.md
+++ b/SKILL.md
@@ -151,13 +151,16 @@ The human removes the cognitive constraint by providing the raw material. The fa
 skill-name/
 ├── SKILL.md          # Starts with "# /skill-name" — the invocation trigger (~15 tools)
 ├── AGENTS.md         # Companion instruction file — AAIF format (~15 tools)
-├── scripts/          # Functional code + run_pipeline.py (multi-script) + run_evals.py
+├── .claude-plugin/   # plugin.json + marketplace.json (/plugin install path)
+├── scripts/          # Functional code + run_pipeline.py (multi-script) + run_evals.py + evolve.py
 ├── references/       # Detailed documentation (loaded on demand)
 ├── assets/           # Templates, schemas, data files
-├── evals/            # Bundled eval spec: binary checks + golden cases
+├── evals/            # Bundled eval spec: binary checks + golden cases (+ judge canary)
 ├── install.sh        # Cross-platform auto-detect installer
 └── README.md         # Multi-platform installation instructions
 ```
+
+(`EVOLUTION.md` appears at the skill root after the first failed check — it accumulates the raw evidence each failure leaves behind.)
 
 Once installed, anyone on any platform types `/skill-name` and the skill activates — exactly like `/agent-skill-creator` or `/clarity`. The generated skill is a first-class citizen, not a second-class output.
 
@@ -230,10 +233,11 @@ Create all files in this order:
 4. Implement Python scripts (functional, no placeholders, no TODOs). **For a multi-script pipeline**, also emit a single `scripts/run_pipeline.py` orchestrator that runs the steps in order and wires output→input **in code** — so the agent runs one command instead of sequencing steps from prose. Skip for genuinely interactive/branching skills. See `references/phase5-orchestration.md`
 5. Write references (detailed documentation the skill loads on demand)
 6. Write assets (templates, configs)
-7. **Emit the eval spec** (skip if `--no-eval`): write `evals/<name>.eval.md` (the binary checks + golden cases derived in Phase 2) and copy `scripts/run_evals_template.py` → the generated skill's `scripts/run_evals.py`. See `references/phase2-eval-assessment.md`
+7. **Emit the eval spec** (skip if `--no-eval`): write `evals/<name>.eval.md` (the binary checks + golden cases derived in Phase 2, one marked `"split": "test"` as the holdout, plus a `judge` block with a pinned model and known-bad canary when any criterion is `llm-judge`) and copy `scripts/run_evals_template.py` → the generated skill's `scripts/run_evals.py`. See `references/phase2-eval-assessment.md`
 8. Generate `install.sh` from `scripts/install-template.sh` (replace `{{SKILL_NAME}}` with actual name, `chmod +x`)
-9. Write `README.md` (multi-platform install instructions showing `git clone` to each tool's **native** path)
-10. Run **validation** against the official spec, **security scan** for hardcoded keys and injection patterns, **`python3 <skill>/scripts/check_pipeline.py <skill>`** (no compile or undeclared-dependency errors), and — if an eval spec was emitted — `python3 <skill>/scripts/run_evals.py --validate` (must report `VALID`)
+8.5. Generate `.claude-plugin/plugin.json` + `marketplace.json` from `scripts/claude-plugin-template/` (placeholders from frontmatter — makes the skill installable via `/plugin marketplace add`), and **ship the evolution toolkit**: copy `scripts/evolve_template.py` → `scripts/evolve.py` plus the staleness/drift/dep-health modules. See `references/pipeline-phases.md` Steps 6.5–6.6
+9. Write `README.md` (multi-platform install instructions showing the `/plugin marketplace add` path for Claude Code and `git clone` to each tool's **native** path)
+10. Run **validation** against the official spec, **security scan** for hardcoded keys, instruction-body injection, and undeclared endpoints, **`python3 <skill>/scripts/check_pipeline.py <skill>`** (no compile or undeclared-dependency errors), and — if an eval spec was emitted — `python3 <skill>/scripts/run_evals.py --validate` (must report `VALID`)
 11. **Auto-install on the current platform** (see below)
 12. Report results to user with clear next steps, including the eval/optimize one-liner from `references/phase2-eval-assessment.md`
 
@@ -579,7 +583,7 @@ The SKILL.md body must start with `# /skill-name` so the agent recognizes the sl
 | Code size | <1000 lines | >2000 lines |
 | Maintenance | Single developer | Team |
 | Structure | Single SKILL.md | Multiple component SKILL.md files |
-| marketplace.json | Not needed | Optional (official fields only) |
+| marketplace.json | Shipped by default (`.claude-plugin/`, Step 6.5) | Shipped by default (official fields only) |
 
 See `references/architecture-guide.md` for detailed decision framework.
 
@@ -633,7 +637,7 @@ See `references/cross-platform-guide.md` for full platform details.
 After generating a skill, run:
 
 - **Spec validation**: Checks frontmatter, naming, structure, line count
-- **Security scan**: Checks for hardcoded API keys, .env files, injection patterns
+- **Security scan**: Checks for hardcoded API keys, .env files, dangerous code patterns, instruction-body prompt injection (override/concealment/exfiltration phrases, hidden unicode, encoded blobs), and undeclared network endpoints in scripts
 
 ```bash
 # Validate a skill

--- a/references/architecture-guide.md
+++ b/references/architecture-guide.md
@@ -19,7 +19,7 @@ Before creating any skill, determine whether it should be a **Simple Skill** or 
 | **Maintenance scope** | Single developer | Team or multi-concern |
 | **Domain breadth** | Single domain focus | Spans multiple sub-domains |
 | **Deployment** | Install as one unit | Components may be used independently |
-| **marketplace.json** | **Not needed** | Optional (official fields only) |
+| **marketplace.json** | Shipped by default (`.claude-plugin/`, Step 6.5) | Shipped by default (official fields only) |
 
 ### 1.2 Decision Flowchart
 
@@ -59,16 +59,19 @@ How many distinct workflows does this skill address?
 
 ## 2. Simple Skill Structure
 
-A Simple Skill is a single, self-contained agent skill that follows the Agent Skills Open Standard. It has one SKILL.md file and no `marketplace.json`.
+A Simple Skill is a single, self-contained agent skill that follows the Agent Skills Open Standard. It has one SKILL.md file plus a `.claude-plugin/` manifest pair for the native plugin install path.
 
 ### 2.1 Standard Directory Layout
 
 ```
 skill-name/
 ├── SKILL.md          # <500 lines, spec-compliant frontmatter
-├── scripts/          # Functional Python code
+├── AGENTS.md         # Companion instruction file (cross-tool reach)
+├── .claude-plugin/   # plugin.json + marketplace.json (/plugin install path)
+├── scripts/          # Functional Python code + run_evals.py + evolve.py
 ├── references/       # Detailed documentation (loaded on demand)
 ├── assets/           # Templates, schemas, data files
+├── evals/            # Bundled eval spec + golden cases
 ├── install.sh        # Cross-platform auto-detect installer
 └── README.md         # Multi-platform installation instructions
 ```
@@ -99,18 +102,18 @@ compatibility: >-           # optional, use when platform-specific features exis
 | `scripts/` | Executable Python code (functional, no placeholders) | Yes (if skill has code) |
 | `references/` | Detailed documentation, API guides, methodology docs | Recommended |
 | `assets/` | Configuration files, templates, schemas, static data | Optional |
+| `.claude-plugin/` | Plugin manifests for `/plugin marketplace add` install | Yes |
+| `evals/` | Eval spec (binary checks + golden cases + judge canary) | Yes (unless `--no-eval`) |
+| `scripts/evolve.py` | Shipped self-maintenance loop (staleness + rollout → `EVOLUTION.md`) | Yes |
 | `install.sh` | Cross-platform installer script | Yes |
 | `README.md` | Installation instructions for 5+ platforms | Yes |
 
-### 2.4 Why No marketplace.json for Simple Skills
+### 2.4 marketplace.json and SKILL.md: complementary, not competing
 
-Per the Agent Skills Open Standard and FR-005:
-
-- SKILL.md is the universal discovery mechanism across all 26+ platforms
-- `marketplace.json` is a Claude Code-specific plugin manifest, not part of the standard
-- Simple skills activate via their SKILL.md `description` field alone
-- Adding `marketplace.json` to a simple skill creates a non-standard structure that may confuse other platforms
-- Skills placed in `~/.claude/skills/` or `.claude/skills/` are discovered automatically by Claude Code without `marketplace.json`
+- SKILL.md remains the universal discovery/activation mechanism across all 17 platforms — the `description` field alone activates the skill everywhere
+- `.claude-plugin/{plugin.json,marketplace.json}` is additive: it gives Claude Code users the native `/plugin marketplace add` + `/plugin install` path (in-tool install, updates, enable/disable). Other platforms simply ignore the directory
+- Because a generated skill has no `skills/` subdirectory, Claude Code discovers its root SKILL.md automatically (root-fallback); never add a `.claude/` directory inside a skill — it can shadow plugin skill discovery
+- Skills copied to `~/.claude/skills/` or `.claude/skills/` are still discovered without the manifests — the plugin path is an addition, not a requirement
 
 ---
 
@@ -912,8 +915,7 @@ Use this checklist before proceeding to implementation (Phase 5):
 - [ ] References planned for detailed content
 - [ ] `install.sh` included
 - [ ] `README.md` planned with multi-platform install instructions
-- [ ] No `marketplace.json` for Simple Skills
-- [ ] If Complex Suite with `marketplace.json`, only official fields used
+- [ ] `.claude-plugin/plugin.json` + `marketplace.json` planned (official fields only, names match SKILL.md)
 - [ ] If suite: shared/ directory planned with import patterns documented
 - [ ] If suite: each component is independently functional
 

--- a/references/cross-platform-guide.md
+++ b/references/cross-platform-guide.md
@@ -177,7 +177,14 @@ Extracts SKILL.md body as plain markdown into `.junie/skills/` directory.
 
 ### Claude Code
 
+```
+# Native plugin path (recommended — in-tool install, updates, enable/disable)
+/plugin marketplace add <github-owner>/<repo>     # or a local path: /plugin marketplace add ./skill-name
+/plugin install skill-name@skill-name
+```
+
 ```bash
+# Or copy directly:
 # User-level (global)
 cp -r skill-name/ ~/.claude/skills/skill-name/
 

--- a/references/phase2-eval-assessment.md
+++ b/references/phase2-eval-assessment.md
@@ -45,8 +45,9 @@ Tag each criterion as one of two grader types:
   `test "$(wc -w < {output})" -lt 150`. **Prefer `command` wherever a reliable
   programmatic check exists.**
 - **`llm-judge`** — graded by a model reading the output. Use only when meaning,
-  tone, or quality cannot be checked by a command. The bundled runner does
-  **not** grade these; it prints them as a checklist.
+  tone, or quality cannot be checked by a command. The bundled runner grades
+  these with `--rollout --judge` (pinned judge + canary — see "Automated
+  llm-judge grading" below); without `--judge` they print as a checklist.
 
 Present the criteria to the user for a thumbs-up before writing them (one short
 confirmation, not a questionnaire).
@@ -166,8 +167,8 @@ After creation, alongside the install/share messaging, print:
 > `python3 scripts/run_evals.py --rollout --promote`
 > To optimize the skill against its metric:
 > `/autoresearch-universal optimize . using evals/<skill-name>.eval.md`
-> (`--rollout` runs the skill's `run` command; `llm-judge` checks are still a
-> printed checklist, not auto-graded.)
+> Grade `llm-judge` checks with the pinned judge: `python3 scripts/run_evals.py --rollout --judge`
+> (needs `ANTHROPIC_API_KEY`; without `--judge` they print as a checklist.)
 
 ## Handoff to autoresearch-universal (rule 18)
 

--- a/references/pipeline-phases.md
+++ b/references/pipeline-phases.md
@@ -26,7 +26,7 @@ Phase 5: IMPLEMENTATION  -> Create all files, validate, security scan
 - Generated SKILL.md must be **<500 lines** (move detail to `references/`)
 - Frontmatter must include: `name`, `description`, `license`, `metadata` (author, version)
 - `install.sh` is generated for cross-platform support
-- `marketplace.json` is **NOT** needed for simple skills
+- `.claude-plugin/` manifests are emitted for every skill (Step 6.5) — additive to SKILL.md activation, never a replacement
 - Validation and security scan run at the end of Phase 5
 
 ---
@@ -649,7 +649,7 @@ skill-name/
 | Code size | <1000 lines | >2000 lines |
 | Maintenance | Single developer | Team |
 | Structure | Single SKILL.md | Multiple component SKILL.md files |
-| marketplace.json | Not needed | Optional (official fields only) |
+| marketplace.json | Shipped by default (`.claude-plugin/`, Step 6.5) | Shipped by default (official fields only) |
 
 **Default:** Start with simple skill. Upgrade to complex suite only when warranted.
 
@@ -1322,7 +1322,7 @@ chmod +x skill-name/install.sh
 
 The template handles:
 - POSIX-compatible shell (`set -eu`, no bashisms)
-- 14 platforms: claude-code, copilot, cursor, windsurf, cline, codex, gemini, kiro, trae, goose, opencode, roo-code, antigravity, universal
+- 17 platforms (see `scripts/platforms.py`, the single source of truth): claude-code, copilot, cursor, windsurf, cline, codex, gemini, kiro, kilo-code, factory, junie, trae, goose, opencode, roo-code, antigravity, universal
 - Corrected paths: Codex → `~/.agents/skills/`, Windsurf → `.windsurf/rules/` (project) / `global_rules.md` (global)
 - Format adapters: auto-generates `.mdc` for Cursor, `.md` rules for Windsurf, plain `.md` for Cline/Roo/Trae
 - Universal `.agents/skills/` secondary symlink after every install

--- a/references/quality-standards.md
+++ b/references/quality-standards.md
@@ -22,7 +22,8 @@
 - Set `metadata.review_interval_days` (default: 90 days)
 - Declare external dependencies in `metadata.dependencies` so health can be checked
 - Declare expected API response shapes in `metadata.schema_expectations` for drift detection
-- Run `python3 scripts/staleness_check.py path/to/skill/` periodically to detect stale skills
+- Generated skills carry the loop themselves: `python3 scripts/evolve.py` (staleness + deps + drift + eval rollout from the skill's own root); failures append raw evidence to the skill's `EVOLUTION.md`
+- From the creator repo, `python3 scripts/staleness_check.py path/to/skill/` (add `--record` to write findings into the skill's `EVOLUTION.md`) works for ad-hoc checks
 - When publishing to a registry, use `python3 scripts/skill_registry.py stale` to audit all skills
 
 ---


### PR DESCRIPTION
Doc-only PR fixing 20 doc/code mismatches found by a systematic audit after PR #15 — stale claims (llm-judge 'not auto-graded', --force scan bypass, 'no marketplace.json for simple skills', 14/26+ platform counts), missing new artifacts in structure trees (.claude-plugin/, evolve.py, evals/), and maintenance docs that predated the shipped evolve loop.

Verification: 246 tests pass, validate.py VALID, example scans clean, no stale phrases remain (grep-swept).