### PR TITLE
feat: Phase 0 spec-ideation front door for vague input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ to semantic versioning where practical.
 ## [Unreleased]
 
 ### Added
+- **Phase 0 spec-ideation front door** (`references/spec-ideation.md`): a
+  pre-Discovery step for when the user arrives without a skill in mind — one word
+  ("freight"), a shrug, "give me a skill idea", or a dumped transcript with no
+  goal. Instead of guessing a skill and building it, the factory harvests the
+  user's *real recurring work* (never invents chores), filters to what it can
+  actually ship (repeatable + markdown/scripts + data-centric + binary-checkable —
+  drops apps/games/firmware), and shapes the chosen chore into the workflow Phase 1
+  needs. Carries an inverted anti-slop rule (the best skill is the boring, repeated
+  chore, not the clever one) and a held-out bellwether: a spec is only proven when
+  the skill it produces passes its own first bundled eval. Validated end-to-end —
+  an emitted spec built a skill that passed 5/5 checks, VALID, and CLEAN.
 - **Cross-runtime native install manifests + README install matrix**: the repo
   now ships `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`
   (Codex CLI), `.github/plugin/{plugin,marketplace}.json` (Copilot CLI),

--- a/SKILL.md
+++ b/SKILL.md
@@ -166,6 +166,22 @@ Once installed, anyone on any platform types `/skill-name` and the skill activat
 
 ## Core Workflow
 
+### Phase 0: Spec Ideation (only when input is too vague to spec)
+
+Most input names a workflow — skip straight to Phase 1. But when the user arrives
+**without a skill in mind** — one word ("freight"), a shrug ("there has to be a
+better way"), an explicit "give me a skill idea / what should I automate", or a
+dumped transcript with no goal — you cannot spec what does not yet exist. Do not
+guess a skill and build it. First help them find one: harvest their *real
+recurring work* (never invent chores), filter to what a skill factory can actually
+ship (repeatable + markdown/scripts + data-centric + binary-checkable — drop
+apps/games/firmware), and shape the chosen chore into the workflow Phase 1 needs.
+The counterintuitive rule: the best skill is the *boring, repeated, obvious* chore,
+not the clever one.
+
+See `references/spec-ideation.md` for the harvest → filter → shape procedure and
+its held-out bellwether.
+
 ### Phase 1: Discovery
 
 Research available APIs and data sources for the user's domain. Compare options by cost, rate limits, data quality, and documentation. **Decide** which API to use with justification.
@@ -749,6 +765,7 @@ The `-skill` suffix also serves as a signal to the agent: when it sees a repo or
 
 | File | Contents |
 |------|----------|
+| `references/spec-ideation.md` | Phase 0 front door: turn vague input / "give me a skill idea" into a grounded, skill-shaped spec |
 | `references/pipeline-phases.md` | Detailed Phase 1-5 instructions |
 | `references/architecture-guide.md` | Simple vs Suite decision, refactoring, cross-component communication, versioning |
 | `references/templates-guide.md` | Template-based creation |

--- a/references/spec-ideation.md
+++ b/references/spec-ideation.md
@@ -1,0 +1,129 @@
+# Spec Ideation — the factory front door for vague input
+
+Most factory input names a workflow ("every week I pull sales data and make a
+report") — go straight to Phase 1. This reference is for the other case: the user
+arrives **without a skill in mind** and needs help finding one *and* shaping it
+into a spec before anything gets built.
+
+Fire this **before Phase 1** when the input is too thin to spec:
+
+- One word or a shrug: `freight`, `here`, `this is ridiculous, there has to be a better way`
+- An explicit ask: "give me a skill idea", "what should I automate", "what could I build with this"
+- A pile with no goal: a dumped transcript / inbox / folder and no stated outcome
+
+If the input already names a concrete recurring workflow, skip this — you'd only
+slow the user down.
+
+## The inversion (read first)
+
+Ideation instincts say "reject the obvious, get novel." **For skills that is
+backwards.** A good skill is *boring, repeated, and obvious* — its value is
+reliability on a chore the user already does every week, not surprise. Spend the
+creativity on *how* to automate the chore, never on *what* to automate. The
+winning candidate is usually the dullest recurring task the user mentions.
+
+## Procedure
+
+### 1 — Harvest real recurring work (never invent)
+
+Do not brainstorm skill ideas in a vacuum — "AI skill ideas" is peak slop. Pull
+the constraint from the user's actual life:
+
+- Ask: "paste your last 15–20 repeated tasks", or "walk me through a typical
+  week", or point me at the folder / inbox / transcript you already have.
+- Atomize into one task per line.
+- Keep only what recurs. A thing done once is not a skill.
+
+If the user gives you nothing to mine, **stop and ask** — a harvested-from-nothing
+idea is fabricated by construction and will fail the grounding check.
+
+### 2 — Filter by skill-fit (kill non-skills before shaping)
+
+A harvested task is skill-worthy only if **all four** hold. Drop the rest — say
+plainly why, and point app/game/firmware ideas at plain coding-agent work instead
+(the factory ships markdown + scripts, not a native binary).
+
+| # | Check | Fails when |
+|---|---|---|
+| 1 | **Repeatable** — recurring trigger, run again and again | it's a one-off build |
+| 2 | **Runs as markdown + scripts** (Python/shell) | needs a native app, game engine, firmware toolchain, or GPU |
+| 3 | **File / data / document / API / inbox centric** | operates on pixels or physical hardware |
+| 4 | **Binary-checkable** — you can write 3–5 yes/no evals + golden cases | success is subjective ("make it delightful") |
+
+### 3 — Shape each survivor as a situated job
+
+State the trigger concretely (Jobs-to-Be-Done form), so it isn't a platitude:
+
+> **When [situation/trigger], I want to [do the chore], so I can [outcome].**
+
+Generic ("when I want to be productive") → reject. Specific ("every Monday when I
+merge five regional CSVs by hand") → keep.
+
+### 4 — Hand off
+
+Present 2–3 shaped candidates, cheapest-win first, and let the user pick one. Then
+either:
+
+- **Continue into the factory** — carry the chosen job into Phase 1/2 as the
+  workflow to build; or
+- **Emit a paste-ready spec** the user can run themselves (the "finished tool as
+  if it already exists" shape):
+
+```
+The finished skill, as if it already exists:
+[one paragraph — who runs it, what triggers it, what it does end to end]
+
+Recurring trigger: [the exact situation that fires it]
+
+The 3 things it must do, in order:
+1. [step]   2. [step]   3. [step]
+
+Inputs it reads: [real files / folders / API / inbox]
+Output it produces: [the artifact]
+"Done" looks like: [an observable end state a stranger could verify]
+
+Grade itself against these binary checks: [3–5 yes/no checks]
+```
+
+The `grade itself against` line seeds Phase 2's eval spec directly — no
+reformatting. Never emit a spec with an empty bracket: that just defers the work
+to the factory as a question, which is the failure this front door exists to prevent.
+
+## Success criteria (loss function)
+
+1. **Zero-question handoff** — the chosen spec enters Phase 1/2 (or pastes back in)
+   with no follow-up questions: trigger, the 3 ordered steps, and "done" are all filled.
+2. **Grounded** — every candidate cites the harvested line it came from, never an
+   invented chore.
+3. **Skill-shaped** — at least one survivor passes all four skill-fit checks;
+   app/game/firmware candidates were dropped in step 2 with a reason.
+
+**Held-out bellwether (never tune against it):** run the emitted spec end to end
+through the factory and confirm the generated skill's *bundled eval passes on its
+first golden case.* This front door never sees that result while generating — it is
+the only check that proves the spec was real, not merely well-formed. If
+well-formed specs keep yielding skills that fail their own first eval, the harvest
+or the skill-fit filter is wrong, not the formatting.
+
+## Worked example
+
+Harvested line: *"every Monday I download 5 regional sales CSVs, paste them into
+one sheet, dedupe by store ID, and email the total to my manager."*
+
+- Skill-fit: repeatable ✓, scripts ✓, file-centric ✓, binary-checkable ✓ → keep.
+- Job: "When it's Monday and the 5 regional CSVs have landed, I want them merged,
+  deduped, and totalled, so I can send one number without an hour of paste."
+- Self-grading checks → "5 files consumed", "no duplicate store IDs", "grand total
+  == sum of per-file totals" — these drop straight into Phase 2's eval spec.
+
+Contrast — *"I want a cozy desktop pet of my cat"*: fails check 4 (delight isn't
+gradeable) and 2/3. Drop it, name why, don't shape it.
+
+## Anti-slop notes
+
+- The failure mode here is **inventing** plausible chores instead of harvesting
+  real ones. If you can't cite the source line, you made it up.
+- Don't get clever. "A skill that generates creative reports" is slop; "a skill
+  that merges these 5 named CSVs and flags rows where Q3 < Q2" is a skill.
+- Don't route apps/games/firmware here to be polite. Say the factory can't ship
+  them and redirect.


### PR DESCRIPTION
## What

Adds a **Phase 0** to the factory: a front door for when the user shows up **without a skill in mind** — one word (\`freight\`), a shrug (\"there has to be a better way\"), an explicit \"give me a skill idea / what should I automate\", or a dumped transcript with no goal.

Today the factory jumps to Phase 1 (Discovery), which assumes the user already knows the skill. For vague input it would guess a skill and build it. Phase 0 closes that gap.

## How

New `references/spec-ideation.md` — a **harvest → filter → shape** procedure:

1. **Harvest** the user's *real recurring work* — never invent chores (if you can't cite the source line, you made it up).
2. **Filter by skill-fit** — four binary checks: repeatable + markdown/scripts + data/file-centric + binary-checkable. Drops apps/games/firmware at the door (the factory ships markdown + scripts, not a native binary) and points them at plain coding-agent work.
3. **Shape** the chosen chore as a situated Jobs-to-Be-Done trigger, then either continue into Phase 1 or emit a paste-ready spec.

Two design decisions worth calling out:
- **Anti-slop is inverted here.** Normal ideation rejects the obvious; for skills the *boring, repeated, obvious* chore is the win. The creativity goes into *how* to automate, not *what*.
- **Held-out bellwether.** A spec is proven only when the skill it produces passes its *own first bundled eval* — the front door never tunes against that check.

Wires a Phase 0 section + reference-table row into `SKILL.md`; notes it in `CHANGELOG.md`.

## Validation

- `scripts/validate.py .` → **VALID**
- End-to-end proof: an emitted spec (an alert-dispatch payload→PDF+dashboard→Resend skill) was run through the real factory and produced a skill that passed **5/5** bundled-eval checks, **VALID**, and security-scan **CLEAN** — the held-out bellwether, green.

## Scope

Docs/instructions only — one new reference file + 17 lines in `SKILL.md` + a CHANGELOG entry. No code paths touched.