### PR TITLE
docs: advertise Phase 0 front door + fix test count on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
 <section class="stats tnum" aria-label="Project facts">
   <div><b>1.8k+</b><span>GitHub stars</span></div>
   <div><b>17</b><span>platforms, one install</span></div>
-  <div><b>246</b><span>tests on the factory itself</span></div>
+  <div><b>250+</b><span>tests on the factory itself</span></div>
   <div><b>MIT</b><span>licensed, no API key to start</span></div>
 </section>
 
@@ -73,6 +73,10 @@
       compliance checklist, a screenshot next to a half-working script. The factory
       reads the material, uncovers the implicit requirements, and writes its own
       internal specification before generating anything.</p>
+      <p>Don’t even know what to build? Say one word — “freight” — or paste a week of
+      repeated tasks. It harvests the boring, repeated chores actually worth
+      automating, drops the ones a skill can’t ship, and shapes the rest into a spec
+      for you.</p>
     </li>
 
     <li class="step" id="gates">


### PR DESCRIPTION
Brings the GitHub Pages landing page current with #19.

- **Phase 0 ramp** added to the Describe stage — the "don't know what to build?" entry point ('freight' / paste your week → harvest → filter → shaped spec). Woven into Describe rather than a new stage, so "Four stages" stays honest and no anchors/numbering shift.
- **Test count 246 → 250+** — authoritative pytest collect is 254; softened to "250+" so it stops going stale every commit (provenance over a number that rots).

Docs-only, HTML parses clean. Auto-redeploys from main/docs on merge.