### PR TITLE
docs: reframe llm-judge as agent-graded, not Anthropic-key-gated

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -129,7 +129,7 @@
   </header>
   <ul class="limits__list">
     <li>Eval rollout is opt-in — it executes the skill’s real code, so you choose when.</li>
-    <li>Judge grading needs an <code>ANTHROPIC_API_KEY</code>; without one it prints a checklist instead of silently passing.</li>
+    <li>Subjective <code>llm-judge</code> criteria are graded by the agent running the skill — the model your runtime already provides — so no extra API key is needed in an agentic runtime. A raw key is only for grading them unattended in CI; either way it never silently passes.</li>
     <li>Artifact signing (cosign/SLSA) is on the roadmap, not shipped.</li>
     <li>The episodic learning layer is a design document, clearly marked not-implemented.</li>
   </ul>


### PR DESCRIPTION
Fixes a misleading 'What it doesn't claim' bullet flagged in review.

**Before:** *"Judge grading needs an ANTHROPIC_API_KEY; without one it prints a checklist instead of silently passing."*

That presents a vendor API key as the primary path and the checklist as a degraded fallback. In an agentic runtime it's backwards — the host agent is already an LLM under the subscription and grades the `llm-judge` criteria itself, keyless. The runner already prints the criteria for exactly that handoff (`run_evals_template.py`). A raw key is only needed for **unattended CI** grading.

**After:** states the real model, provider-neutral (no vendor named in the visible claim), still honest that it never silently passes.

Docs-only; HTML parses clean. Note: this is the framing fix. The underlying `--judge` CI path is still Anthropic-only in code — a separate provider-agnostic refactor is proposed in the follow-up.