### PR TITLE
docs: record llm-judge provider lesson in LEARNINGS

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -23,3 +23,24 @@ you remember them.
 **When to apply:** any change that adds a generated file, validator, or
 Phase-5 step. Treat as a checklist item before declaring a Phase-5 feature
 done. Quick grep: `grep -n "## Files\|Report Results\|Validation: PASSED" references/pipeline-phases.md`.
+
+## 2026-07-20 — Don't gate LLM-judge behind one provider's API key
+
+In a cross-runtime factory ("17 platforms"), the `llm-judge` grader is **not** a
+bundled vendor API call. In an agentic runtime the host agent is already an LLM
+under the user's subscription and grades the criteria itself, keyless — the
+runner prints the criteria for exactly that handoff. A raw API key
+(`ANTHROPIC_API_KEY` today) is only needed for **unattended CI** grading, where no
+agent is present.
+
+**Why:** the landing page framed a raw `ANTHROPIC_API_KEY` as the primary judge
+path and the checklist as a degraded fallback. That's backwards for every agentic
+runtime and provider-locks a tool that markets cross-platform support (user
+review, 2026-07-20). Decision: keep the CI path Anthropic-only for now (YAGNI —
+in-runtime grading is keyless and covers the common case); a provider-agnostic CI
+judge (OpenAI-compatible `JUDGE_BASE_URL`) is a future option, not shipped.
+
+**When to apply:** any docs or code describing how evals/judges run. State
+agent-graded-in-runtime (keyless) as primary; a raw key is CI-only; never name a
+single vendor as *required* in a visible cross-platform claim. Quick grep:
+`grep -rni "ANTHROPIC_API_KEY\|llm-judge" docs/ README.md references/`.


### PR DESCRIPTION
Records the design lesson from review: the llm-judge grader is agent-graded and keyless in an agentic runtime; a raw API key is CI-only and should never be presented as the required/primary path in a cross-platform tool. Decision captured: CI path stays Anthropic-only for now (YAGNI). Docs-only.