### PR TITLE
feat: require explicit run-vs-read labels on bundled files

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -35,7 +35,7 @@ User invokes `/agent-skill-creator` followed by their input:
 ```
 /agent-skill-creator Every week I pull sales data, clean it, and generate a report
 /agent-skill-creator https://wiki.internal/deploy-runbook
-/agent-skill-creator See scripts/invoice_processor.py — turn it into a reusable skill
+/agent-skill-creator See src/invoice_processor.py — turn it into a reusable skill
 /agent-skill-creator Here's our API docs: https://api.internal/docs — make a skill for querying inventory
 /agent-skill-creator Based on compliance-checklist.pdf, create a skill for SOX audits
 /agent-skill-creator --mcp-audit https://github.com/vendor/mcp-server — we pay for this data, what skills can we build on it?
@@ -814,8 +814,9 @@ self-maintenance command:
 - A `"split": "test"` holdout case is scored only at release, never fed to an optimization loop
 - `evolve.py` runs staleness/dependency/drift checks + the rollout in one command; every failure appends its raw evidence to the skill's `EVOLUTION.md`, which feeds a regenerate pass
 
-`references/agentdb-integration.md` is a design sketch for a future episodic
-learning layer — it is NOT implemented; never present it as current behavior.
+Read `references/agentdb-integration.md` as a design sketch only — it describes a
+future episodic learning layer that is NOT implemented; never present it as
+current behavior.
 
 ## Quality Standards
 
@@ -825,6 +826,7 @@ learning layer — it is NOT implemented; never present it as current behavior.
 - Robust error handling
 - Real content in references (not "see docs")
 - A `## Gotchas` section carrying the environment-specific facts that defy reasonable assumptions
+- Explicit "run this" / "read this" labels — every `scripts/` mention leads with a run command, every `references/` mention with a read cue
 - Configs with real values
 
 **Never**:

--- a/references/examples/stock-analyzer/SKILL.md
+++ b/references/examples/stock-analyzer/SKILL.md
@@ -346,7 +346,7 @@ matplotlib>=3.7.0
 
 ## Gotchas
 
-- **The bundled `scripts/main.py` returns hardcoded mock prices, not market data.**
+- **Running the bundled `scripts/main.py` returns hardcoded mock prices, not market data.**
   `_fetch_data()` returns the same `close: 178.45` for every ticker, and
   `_calculate_indicator()` returns fixed RSI/MACD/Bollinger values. Asking for TSLA
   returns AAPL-shaped numbers. This is deliberate — it keeps the example

--- a/references/phase5-orchestration.md
+++ b/references/phase5-orchestration.md
@@ -66,6 +66,33 @@ if __name__ == "__main__":
 
 The SKILL.md then documents one command: `python scripts/run_pipeline.py --source <X>`.
 
+## Say which files to run and which to read
+
+A skill bundles two kinds of file the agent must treat differently: scripts it
+should **execute**, and references it should **read**. The `scripts/` vs
+`references/` split encodes that for a human reading the tree, but the agent is
+reading prose — and left to infer, it will sometimes read a script as
+documentation (losing the determinism the script existed to provide) or try to
+execute a reference.
+
+Label every mention with the action, not just the path:
+
+| Instead of | Write |
+|---|---|
+| `` `scripts/run_pipeline.py` produces the summary `` | **Run** `python3 scripts/run_pipeline.py --input <X>` — produces the summary |
+| `` See `references/api-guide.md` `` (in a scripts section) | **Read** `references/api-guide.md` for endpoint details |
+| `` `scripts/fetch.py` handles auth `` | **Run** `python3 scripts/fetch.py` to fetch; it handles auth |
+
+Two conventions that make this automatic:
+
+- Put every runnable command inside a ```bash fence. A shell fence is
+  self-evidently an instruction to execute, and needs no verb in the prose.
+- Give the `## References` table a "when to read this" column rather than a bare
+  file list, so the read intent is stated once for the whole table.
+
+`validate.py` warns when a `scripts/` or `references/` path appears with no action
+verb on its line or the line before. Shell fences and table rows are exempt.
+
 ## LLM steps: pinned model + usage sidecar
 
 Some pipelines have a step that is genuinely a model call (summarize, classify,

--- a/references/pipeline-phases.md
+++ b/references/pipeline-phases.md
@@ -1029,7 +1029,9 @@ metadata:
 
 ## Available Scripts
 
-[Brief description of each script, inputs, outputs]
+[Each script: the command that RUNS it, then inputs and outputs. Lead with the
+verb — "Run `python3 scripts/x.py --input <f>`" — never a bare path, so the agent
+never has to guess whether to execute the file or read it.]
 
 ## Available Analyses
 
@@ -1053,7 +1055,8 @@ metadata:
 
 ## References
 
-[Table of reference files and what they contain]
+[Table of reference files with a "when to read this" column — these are READ on
+demand, never executed]
 ```
 
 **Keeping under 500 lines:** Move detailed content to `references/`:
@@ -1681,6 +1684,7 @@ See README.md for complete multi-platform installation instructions.
 - [ ] No TODO, no `pass`, no `NotImplementedError`, no placeholders
 - [ ] All scripts have: shebang, docstrings, type hints, error handling
 - [ ] Multi-script skill has one `scripts/run_pipeline.py` orchestrator (steps wired in code, one happy-path command)
+- [ ] Every `scripts/` mention says to RUN it and every `references/` mention says to READ it — no bare paths (`validate.py` warns on unlabeled mentions)
 - [ ] `check_pipeline.py` reports no errors (scripts compile, third-party deps declared)
 - [ ] Input validation implemented (reject bad inputs with structured JSON errors)
 - [ ] Output sanity checks implemented (warn on extreme values)
@@ -1770,6 +1774,8 @@ These standards apply across ALL phases and ALL generated files.
 | No `## Gotchas` section | Carry the Phase 1 quirks list and every correction made while verifying (`None known` if there genuinely are none) |
 | Inventing gotchas to fill the section | Only real, observed behavior — a fabricated gotcha teaches a false constraint the agent will work around |
 | Installing an imported skill unscanned | `--audit` it first; registry installs re-scan rather than trusting the cached verdict |
+| `` `scripts/fetch.py` handles auth `` | **Run** `python3 scripts/fetch.py` — a bare path leaves the agent guessing whether to execute it or read it |
+| `` `references/api-guide.md` has the endpoints `` | **Read** `references/api-guide.md` for the endpoints |
 | marketplace.json as step 0 | SKILL.md is the primary file, created first |
 | Name missing `-skill` suffix | End every skill name with `-skill`: `stock-analyzer-skill` |
 | Description over 1024 chars | Trim to essential keywords within limit |

--- a/scripts/tests/test_validate.py
+++ b/scripts/tests/test_validate.py
@@ -99,5 +99,70 @@ class TestGotchasCheck(unittest.TestCase):
         self.assertEqual(len(gotchas_warnings(validate_skill(str(skill)))), 1)
 
 
+LABEL_HINT = "do not say what to do with the file"
+
+
+def label_warnings(result: dict) -> list[str]:
+    return [w for w in result["warnings"] if LABEL_HINT in w]
+
+
+class TestRunVsReadLabeling(unittest.TestCase):
+    """A bare path leaves the agent guessing whether to execute or read a file."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.n = 0
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def check(self, body: str) -> list[str]:
+        self.n += 1
+        skill = write_skill(self.base, f"label{self.n}-skill", "## Gotchas\n\nNone known.\n\n" + body)
+        return label_warnings(validate_skill(str(skill)))
+
+    def test_bare_script_path_warns(self):
+        found = self.check("`scripts/fetch.py` handles authentication.")
+        self.assertEqual(len(found), 1)
+        self.assertIn("scripts/fetch.py", found[0])
+
+    def test_run_verb_clears_it(self):
+        self.assertEqual(self.check("Run `python3 scripts/fetch.py` to fetch the data."), [])
+
+    def test_verb_on_previous_line_counts(self):
+        self.assertEqual(self.check("Run the fetch step:\n\n`scripts/fetch.py --input x`"), [])
+
+    def test_shell_fence_needs_no_verb(self):
+        body = "Fetch the data:\n\n```bash\npython3 scripts/fetch.py --input x\n```"
+        self.assertEqual(self.check(body), [])
+
+    def test_bare_reference_path_warns(self):
+        found = self.check("`references/api-guide.md` has the endpoint list.")
+        self.assertEqual(len(found), 1)
+        self.assertIn("references/api-guide.md", found[0])
+
+    def test_read_verb_clears_it(self):
+        self.assertEqual(self.check("Read `references/api-guide.md` for the endpoints."), [])
+
+    def test_table_rows_are_exempt(self):
+        """Reference tables carry the read intent in the column header."""
+        body = "| File | Contents |\n|---|---|\n| `references/api-guide.md` | Endpoints |"
+        self.assertEqual(self.check(body), [])
+
+    def test_multiple_mentions_collapse_into_one_warning(self):
+        body = "`scripts/a.py` does A.\n\n`scripts/b.py` does B.\n\n`scripts/c.py` does C."
+        found = self.check(body)
+        self.assertEqual(len(found), 1)
+        self.assertIn("3 script mention(s)", found[0])
+
+    def test_warning_only_never_invalid(self):
+        self.n += 1
+        skill = write_skill(self.base, "labelvalid-skill", "`scripts/x.py` exists.")
+        result = validate_skill(str(skill))
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["errors"], [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -33,6 +33,34 @@ MAX_BODY_LINES_WARNING = 500
 # of an otherwise-working skill.
 GOTCHAS_HEADING_PATTERN = re.compile(r"^\s{0,3}#{1,6}\s+gotchas\b", re.IGNORECASE | re.MULTILINE)
 
+# --- Run-vs-read labeling ---
+#
+# A skill bundles two kinds of file the agent must treat differently: scripts it
+# should EXECUTE, and references it should READ. Left to inference, an agent will
+# sometimes read a script as documentation (losing the determinism the script
+# existed to provide) or try to execute a reference. The directory split alone
+# does not say which is which -- the SKILL.md has to.
+#
+# This is a heuristic on a natural-language body, so it is warning-level and
+# deliberately generous: a mention counts as labeled if an action verb appears on
+# its line or the line before. Shell fences are self-evidently executable and
+# table rows carry their verb in the column header, so both are skipped.
+SCRIPT_MENTION_PATTERN = re.compile(r"(?<![\w/])scripts/[\w./-]+\.(?:py|sh|ps1|bat)")
+REFERENCE_MENTION_PATTERN = re.compile(r"(?<![\w/])references/[\w./-]+\.md")
+RUN_VERB_PATTERN = re.compile(
+    r"\b(run|runs|running|execute|executes|executing|invoke|invokes|call|calls|"
+    r"python3?|bash|sh|copy|copies|emit|emits|write|writes|generate|generates)\b",
+    re.IGNORECASE,
+)
+READ_VERB_PATTERN = re.compile(
+    r"\b(read|reads|see|consult|consults|refer|refers|reference|guide|guidance|"
+    r"documented|documents|described|describes|detail|details|listed|explains)\b",
+    re.IGNORECASE,
+)
+SHELL_FENCE_PATTERN = re.compile(r"^\s*```\s*(\w+)?")
+SHELL_FENCE_LANGUAGES = {"bash", "sh", "shell", "console", "zsh", "powershell", "ps1"}
+MAX_REPORTED_UNLABELED = 4
+
 # Pattern for valid skill names: lowercase letters, numbers, hyphens
 NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 CONSECUTIVE_HYPHENS_PATTERN = re.compile(r"--")
@@ -70,6 +98,76 @@ def _extract_local_links(body: str) -> list[str]:
         if target:
             paths.append(target)
     return paths
+
+
+def _find_unlabeled_mentions(body: str) -> tuple[list[str], list[str]]:
+    """
+    Find file mentions that never say whether to run the file or read it.
+
+    Walks the body line by line, skipping shell code fences (self-evidently
+    executable) and markdown table rows (the verb lives in the column header). A
+    mention is considered labeled when an action verb appears on its own line or
+    the line immediately before it, which is where "Run `scripts/x.py`" and
+    "See `references/y.md`" both put it.
+
+    Args:
+        body: The SKILL.md body, frontmatter already stripped.
+
+    Returns:
+        (unlabeled_scripts, unlabeled_references), each formatted "line N: path".
+    """
+    lines = body.split("\n")
+    unlabeled_scripts: list[str] = []
+    unlabeled_references: list[str] = []
+    in_shell_fence = False
+    in_fence = False
+    previous_prose = ""
+
+    for index, line in enumerate(lines):
+        fence = SHELL_FENCE_PATTERN.match(line)
+        if fence:
+            if in_fence:
+                in_fence = False
+                in_shell_fence = False
+            else:
+                in_fence = True
+                in_shell_fence = (fence.group(1) or "").lower() in SHELL_FENCE_LANGUAGES
+            continue
+
+        if in_shell_fence or line.lstrip().startswith("|"):
+            continue
+
+        # The paths themselves must not supply the verb: "api-guide.md" contains
+        # "guide", "scripts/run_pipeline.py" contains "run". Strip every mention
+        # before looking for an action word.
+        stripped = REFERENCE_MENTION_PATTERN.sub(" ", SCRIPT_MENTION_PATTERN.sub(" ", line))
+        # Look back to the nearest non-blank line, so a blank line between the
+        # instruction and the path does not hide the verb.
+        context = previous_prose + " " + stripped
+        if stripped.strip():
+            previous_prose = stripped
+
+        if not RUN_VERB_PATTERN.search(context):
+            for match in SCRIPT_MENTION_PATTERN.finditer(line):
+                unlabeled_scripts.append(f"line {index + 1}: {match.group()}")
+
+        if not READ_VERB_PATTERN.search(context):
+            for match in REFERENCE_MENTION_PATTERN.finditer(line):
+                unlabeled_references.append(f"line {index + 1}: {match.group()}")
+
+    return unlabeled_scripts, unlabeled_references
+
+
+def _format_unlabeled(kind: str, directive: str, found: list[str]) -> str:
+    """Build the warning text for one class of unlabeled mention."""
+    shown = ", ".join(found[:MAX_REPORTED_UNLABELED])
+    if len(found) > MAX_REPORTED_UNLABELED:
+        shown += f", and {len(found) - MAX_REPORTED_UNLABELED} more"
+    return (
+        f"{len(found)} {kind} mention(s) do not say what to do with the file "
+        f"({shown}). Say \"{directive}\" explicitly so the agent does not have to "
+        f"guess whether to execute it or read it."
+    )
 
 
 def validate_skill(skill_path: str) -> dict:
@@ -211,6 +309,17 @@ def validate_skill(skill_path: str) -> dict:
                 "environment-specific facts that defy reasonable assumptions live — "
                 "the part a model cannot supply on its own. Write 'None known' if "
                 "the skill genuinely has none."
+            )
+
+        # Run-vs-read labeling
+        unlabeled_scripts, unlabeled_references = _find_unlabeled_mentions(body)
+        if unlabeled_scripts:
+            warnings.append(
+                _format_unlabeled("script", "Run `python3 scripts/x.py`", unlabeled_scripts)
+            )
+        if unlabeled_references:
+            warnings.append(
+                _format_unlabeled("reference", "Read `references/x.md` for ...", unlabeled_references)
             )
 
     # license field


### PR DESCRIPTION
Closes the last gap in the deterministic-scripts practice, raised in review of #28.

## The gap

A skill bundles two kinds of file the agent must treat differently: scripts it should **execute**, and references it should **read**. That distinction was carried only implicitly — by the `scripts/` vs `references/` directory split, and by references being annotated "loaded on demand". Nothing told a skill author to label a file, and nothing checked.

Left to infer, an agent will sometimes read a script as documentation — losing exactly the determinism the script existed to provide — or try to execute a reference.

## Doctrine

- New **"Say which files to run and which to read"** section in `references/phase5-orchestration.md`, with a before/after table and two conventions that make labeling automatic (put runnable commands in ```bash fences; give the References table a "when to read this" column).
- Two rows added to the anti-pattern table in `pipeline-phases.md`.
- Run/read cues in the Step 2 body template for `## Available Scripts` and `## References`.
- A Phase 5 checklist item, and an `Always` entry in the root `SKILL.md`.

## Enforcement

`validate.py` warns when a `scripts/` or `references/` path appears with no action verb nearby.

It is a heuristic over natural-language prose, so it is **warning-level and deliberately generous**:

- Shell fences are self-evidently executable — exempt.
- Table rows carry their verb in the column header — exempt.
- The verb may sit on the mention's own line **or** the nearest non-blank line above it.
- All mentions collapse into one warning per kind, listing up to 4 examples.

## Two bugs the tests caught

Both would have made the check silently useless:

1. **The verb patterns matched inside the paths themselves.** `api-guide.md` contains "guide"; `run_pipeline.py` contains "run". Every mention labeled itself, so the check found nothing. Mentions are now stripped from the line before the verb search.
2. **Lookback used the literal previous line.** The blank line in the very common `Run the fetch step:` → blank → `` `scripts/fetch.py` `` pattern hid the verb. It now looks back to the nearest non-blank line.

## Dogfooded

The three bundled examples and the creator's own `SKILL.md` all report clean. Three real ambiguities were fixed rather than exempted:

- `stock-analyzer`'s mock-price gotcha (bare `scripts/main.py` → "Running the bundled...")
- A trigger example pointing at `scripts/invoice_processor.py` for a file the *user* supplies — now `src/`, which is both more realistic and unambiguous
- A bare `references/agentdb-integration.md` mention → "Read ... as a design sketch only"

## Verification

- 304 tests pass (9 new, covering bare paths, run/read verbs, previous-line lookback, shell fences, table exemption, and warning-not-error)
- `ruff check` clean, zero high-severity `security_scan.py` findings
- All 3 examples validate; the new check reports clean on every skill in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)