### PR TITLE
refactor: bring the creator's own SKILL.md under the 500-line rule it teaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ agent-skill-creator/
   references/                   # Detailed docs (loaded by the agent on demand)
     spec-ideation.md            # Phase 0: vague input → grounded, skill-shaped spec
     mcp-audit.md                # --mcp-audit: vendor MCP server → capability map
+    skill-audit.md              # --audit: vetting a skill you didn't write
+    distribution-guide.md       # Install paths, share-with-team, registry, update check
     pipeline-phases.md          # Full 5-phase creation pipeline
     architecture-guide.md       # Skill structure decisions
     quality-standards.md        # Code and documentation standards

--- a/SKILL.md
+++ b/SKILL.md
@@ -62,9 +62,6 @@ The user can also drop artifacts, paste URLs, share screenshots, or provide mini
 
 /agent-skill-creator [pastes 3 corporate documents: brand voice guidelines, editorial style guide, visual design system]
   we need everyone writing and designing to follow these
-
-/agent-skill-creator [pastes company wiki page about tone of voice + compliance rules + approved templates]
-  make a skill so the agents know our standards
 ```
 
 The user can also activate naturally without the prefix:
@@ -211,57 +208,20 @@ held-out human spot-check.
 
 ### Skill Audit (`--audit` — vet a skill you did not write)
 
-When the user points at a skill **they did not create** — a download, a colleague's
-folder, a registry entry, anything arriving from outside — the deliverable is a
-verdict on whether it is safe to install, not a build.
+When the user points at a skill **they did not create** — a download, a colleague's folder, a registry entry — the deliverable is a verdict on whether it is safe to install, not a build.
 
-This matters because a skill is not a document. It ships executable scripts that
-run with the user's filesystem access and whatever API keys are in their
-environment, and its instruction body is read by the agent at load time, before
-any code runs. Installing one is taking a dependency on a stranger's software.
-Treat it the way you would treat an unfamiliar package.
+A skill is not a document. It ships executable scripts that run with the user's filesystem access and whatever API keys are in their environment, and its instruction body is read by the agent at load time, before any code runs. Installing one is taking a dependency on a stranger's software.
 
-Run both gates and report what they found:
+Run both gates, then answer in plain language: what does it reach, what can it read or write, does the instruction body try to steer the agent, and does the code match what the frontmatter claims?
 
 ```bash
-python3 scripts/validate.py <path>       # structure, naming, frontmatter
-python3 scripts/security_scan.py <path>  # the part that matters here
+python3 scripts/validate.py <path>
+python3 scripts/security_scan.py <path>
 ```
 
-Then answer these four questions in plain language. Do not just print the scanner
-output — the user asked whether to trust it.
+Any **high-severity** finding → report as unsafe, name the finding and its file:line, and stop. Never install it and never offer a workaround. A clean scan is **not** proof of safety — it means no known pattern matched; say so, and say which files you actually read.
 
-1. **What does it reach?** `security_scan.py` cross-checks every network endpoint
-   found in `scripts/` against the hosts declared in the SKILL.md frontmatter.
-   An undeclared endpoint is the finding that matters most: the skill contacts
-   something its own documentation does not mention.
-2. **What can it read or write?** Walk the scripts for filesystem paths and
-   environment-variable reads. A skill that reads `~/.aws/credentials` or
-   `os.environ` broadly, without a stated reason, is the thing to flag.
-3. **Does the instruction body try to steer the agent?** The scanner flags
-   override phrasing, concealment and exfiltration directives, invisible or
-   bidirectional unicode, and long encoded blobs. Any hit here is more serious
-   than a code finding — it executes on load, and hidden unicode exists
-   specifically to survive human review.
-4. **Who wrote it, and does the code match the description?** Compare what the
-   frontmatter claims with what the scripts actually do. A mismatch is a finding
-   even when nothing pattern-matches.
-
-**Verdict rules:**
-
-- Any **high-severity** finding → report as unsafe to install, name the finding
-  and its file:line, and stop. Do not install it, and do not offer a workaround.
-- Medium or low findings → report them plainly and let the user decide, saying
-  which ones would matter given what the skill claims to do.
-- A clean scan is **not proof the skill is safe**. It means no known pattern
-  matched. Say so, and say what you actually read. A scanner cannot recognize
-  intent, and a skill can do harm with entirely ordinary-looking code.
-- If the skill's scripts are too large to read in full, say which files you read
-  and which you did not, rather than implying whole-package coverage.
-
-Anything imported from outside goes through this before it is installed —
-including registry installs, which now re-scan at install time rather than
-trusting the catalog's cached verdict.
+Read `references/skill-audit.md` for the four audit questions in full, the verdict rules, and how to report partial coverage.
 
 ### Phase 1: Discovery
 
@@ -344,290 +304,19 @@ After the skill passes validation and security scan, install it immediately on t
 
 **This path is for skills the factory just built.** A skill that came from anywhere else — a download, a colleague, a registry, a repo — must clear `--audit` first (see above). Auto-install never runs on an unscanned imported skill: the scan is what makes the install safe, and a skill this factory did not produce has not been scanned yet.
 
-**Detection logic** (check in order, install to each tool's **native** path):
+Detect the platform by which config directory exists (`~/.claude/`, `~/.copilot/`, `.cursor/`, `~/.gemini/`, and ten more), install to that tool's **native** path, then symlink into `~/.agents/skills/` so tools reading the universal path find it too. Some platforms need the SKILL.md adapted to their own format.
 
-```
-~/.claude/              exists → Claude Code         → ~/.claude/skills/
-~/.copilot/             exists → GitHub Copilot CLI  → ~/.copilot/skills/
-.github/                exists → VS Code Copilot     → .github/skills/ (project)
-.cursor/                exists → Cursor              → .cursor/skills/ (project only, no global path)
-~/.codeium/windsurf/    exists → Windsurf            → ~/.codeium/windsurf/skills/ (global) + format adapt
-.windsurf/              exists → Windsurf            → .windsurf/rules/ (project) + format adapt
-.clinerules/ or ~/.cline/ exists → Cline             → .clinerules/skills/ or ~/.cline/skills/
-~/.gemini/              exists → Gemini CLI          → ~/.gemini/skills/
-.kiro/                  exists → Kiro                → .kiro/skills/ (project)
-.trae/                  exists → Trae                → .trae/rules/ + format adapt (plain .md)
-.roo/                   exists → Roo Code            → .roo/skills/
-~/.config/goose/        exists → Goose               → ~/.config/goose/skills/
-~/.config/opencode/     exists → OpenCode            → ~/.config/opencode/skills/
-~/.agents/              exists → Universal           → ~/.agents/skills/
-```
-
-After installing to the native path, **also create a symlink at `~/.agents/skills/`** so the skill is discoverable by tools reading the universal path (Codex CLI, Gemini CLI, OpenCode, Goose, Cline, Roo Code).
-
-**Format adaptation**: For Tier 2 platforms (Cursor, Windsurf, Trae), also generate the native format alongside SKILL.md:
-- **Cursor**: Generate `.mdc` file with `alwaysApply: true` and description from frontmatter
-- **Windsurf**: Generate plain `.md` rule, respect 6,000 char per-file limit
-- **Trae**: Generate plain `.md` rule with `type: Always` frontmatter
-
-**Install action**: Copy or symlink the generated skill directory into the platform's native skill path:
-
-```bash
-# Claude Code (user-level):
-cp -R ./sales-report-skill ~/.claude/skills/sales-report-skill
-
-# GitHub Copilot (user-level — Copilot's own path, not Claude's):
-cp -R ./sales-report-skill ~/.copilot/skills/sales-report-skill
-
-# GitHub Copilot (project-level):
-cp -R ./sales-report-skill .github/skills/sales-report-skill
-
-# Cursor (project-level ONLY — no global path exists):
-cp -R ./sales-report-skill .cursor/skills/sales-report-skill
-
-# Gemini CLI (native path):
-cp -R ./sales-report-skill ~/.gemini/skills/sales-report-skill
-```
-
-**After installing, tell the user exactly what to do next:**
-
-```
-Skill installed successfully.
-
-To use it, open a new session and type:
-
-  /sales-report-skill Generate the weekly report for the West region
-
-The skill is installed at: ~/.claude/skills/sales-report-skill
-```
-
-If you cannot detect the platform, show the user how to run the install manually:
-
-```
-I couldn't auto-detect your platform. To install, run:
-
-  ./sales-report-skill/install.sh
-
-Or specify your platform:
-
-  ./sales-report-skill/install.sh --platform cursor
-
-Or install to all detected platforms at once:
-
-  ./sales-report-skill/install.sh --all
-
-Alternative (if npx is available):
-
-  npx skills add ./sales-report-skill
-```
-
-The `install.sh` inside the skill handles auto-detection, platform-specific paths, project vs user level, dry-run mode, and post-install activation instructions. It is the fallback for users who receive the skill as a package (not created in their current session).
-
-The generated skill must be a self-contained package that anyone can install with `git clone` or `./install.sh` and invoke with `/skill-name` — the same way agent-skill-creator itself works.
+Read `references/distribution-guide.md` for the full detection table, the per-platform paths, the confirmation message to show the user, and the `install.sh` fallback when detection fails.
 
 ### Share With Your Team (Post-Creation)
 
-After installing the skill locally, always ask:
+After installing locally, **always ask** whether the user wants to share the skill with their team.
 
-```
-Want to share this skill with your team so they can install it too?
-```
+Corporate users don't know what a registry is, how to `git push`, or what `skill_registry.py` does. They just want their colleague to have the same skill. If they say yes, you do all of it: `git init`, create the remote with whichever CLI is authenticated (`gh` or `glab`), tag it `agent-skill` for org-wide discoverability, and hand back a one-line `git clone` command they can paste into Slack.
 
-Corporate users don't know what a registry is, how to `git push`, or what `skill_registry.py` does. They just want their colleague to have the same skill. You handle everything.
+If they say no, that is fine — the skill is installed and working, and they can share later.
 
-**If the user says yes, do all of this automatically:**
-
-1. **Initialize a git repo** inside the generated skill directory:
-   ```bash
-   cd ./sales-report-skill
-   git init
-   git add -A
-   git commit -m "feat: Initial skill — sales-report-skill"
-   ```
-
-2. **Detect the team's git platform** and create a remote repo:
-
-   Check which CLI tools are available and authenticated:
-
-   ```
-   gh auth status    → GitHub (github.com or GitHub Enterprise)
-   glab auth status  → GitLab (gitlab.com or self-hosted)
-   ```
-
-   **If `gh` is available (GitHub):**
-   ```bash
-   gh repo create sales-report-skill --public --source=. --push
-   gh repo edit --add-topic agent-skill
-   ```
-
-   **If `glab` is available (GitLab):**
-   ```bash
-   glab repo create sales-report-skill --public --defaultBranch main
-   git remote add origin <returned-url>
-   git push -u origin main
-   glab repo edit --topic agent-skill
-   ```
-
-   The `agent-skill` topic makes skills discoverable across the org. Teams can search `topic:agent-skill` on GitHub or filter by topic on GitLab to find all shared skills.
-
-   **If both are available**, check the existing git remotes in the current project to infer which platform the team uses. If the current project's `origin` points to `gitlab.com` or a GitLab instance, use `glab`. Otherwise default to `gh`.
-
-   **If neither is available**, tell the user:
-   ```
-   I can't create the repo automatically. To share this skill:
-   1. Create a new repo on GitHub or GitLab called "sales-report-skill"
-   2. Then run:
-      git remote add origin <repo-url>
-      git push -u origin main
-   3. Share the git clone link with your team
-   ```
-
-3. **Give the user a shareable one-liner** they can send to colleagues:
-   ```
-   Shared! Your colleagues can install it by pasting this in their terminal:
-
-     git clone <repo-url> ~/.claude/skills/sales-report-skill
-
-   Or for VS Code Copilot:
-
-     git clone <repo-url> .github/skills/sales-report-skill
-
-   Or for Cursor:
-
-     git clone <repo-url> .cursor/rules/sales-report-skill
-   ```
-
-   Use the actual repo URL from step 2 (GitHub or GitLab). The install pattern is identical regardless of git platform.
-
-4. **Optionally publish to the team registry** (if the agent-skill-creator registry is available):
-   ```bash
-   python3 scripts/skill_registry.py publish ./sales-report-skill/ --tags <auto-generated-tags>
-   ```
-
-The goal: the user who created the skill sends a one-liner to their colleague on Slack or Teams. The colleague pastes it. Done. No registry knowledge, no `skill_registry.py`, no understanding of the spec. Just `git clone` and it works — whether the team uses GitHub or GitLab.
-
-**If the user says no**, that's fine — the skill is already installed locally and working. They can always share later.
-
-### Set Up a Team Skill Registry
-
-When a user mentions a team, organization, or colleagues — or when they ask about sharing skills at scale — offer to create a **team skill registry**. This is a shared git repo that acts as the central catalog where all team members publish and install skills.
-
-This is the model for AI consultants enabling corporate teams:
-1. The consultant teaches each team member to install and use agent-skill-creator
-2. The consultant creates one shared `{team}-skills-registry` repo on GitHub/GitLab
-3. Each team member creates skills from their own workflows using `/agent-skill-creator`
-4. Each member publishes to the shared registry
-5. Other members browse, search, and install from that same registry
-
-The consultant delivers **knowledge and infrastructure**, not skills. The team creates the skills themselves — they know their workflows better than anyone.
-
-```
-Want me to set up a shared skill registry for your team? It's a single
-repo where everyone publishes their skills and anyone can browse and
-install them — like an internal app store for agent skills.
-```
-
-**If the user says yes, do all of this automatically:**
-
-1. **Ask for the team or org name** to use in the registry name (e.g., "engineering", "acme-corp"):
-
-2. **Initialize the registry**:
-   ```bash
-   mkdir -p ~/{team}-skills-registry
-   python3 scripts/skill_registry.py init --registry ~/{team}-skills-registry --name "{Team Name} Skills"
-   ```
-
-3. **Create a remote repo** (same GitHub/GitLab detection as skill sharing):
-   ```bash
-   cd ~/{team}-skills-registry
-   git init && git add -A && git commit -m "feat: Initialize {team} skill registry"
-
-   # GitHub
-   gh repo create {team}-skills-registry --private --source=. --push
-   gh repo edit --add-topic agent-skill-registry
-
-   # Or GitLab
-   glab repo create {team}-skills-registry --private --defaultBranch main
-   git remote add origin <url> && git push -u origin main
-   ```
-
-   The registry repo should be **private** by default (internal to the org). The team admin controls who has access via GitHub/GitLab repo permissions.
-
-4. **If a skill was just created**, publish it as the first entry:
-   ```bash
-   python3 scripts/skill_registry.py publish ./sales-report-skill/ --registry ~/{team}-skills-registry --tags sales,reports
-   cd ~/{team}-skills-registry && git add -A && git commit -m "feat: Add sales-report-skill" && git push
-   ```
-
-5. **Give the user a team onboarding guide** they can share on Slack, Teams, or email:
-
-   ```
-   Registry is live! Share this with your team:
-
-   ──────────────────────────────────────────────
-   TEAM SKILL REGISTRY — Quick Start
-   ──────────────────────────────────────────────
-
-   STEP 1: Install agent-skill-creator (one time)
-
-     git clone https://github.com/FrancyJGLisboa/agent-skill-creator.git ~/.claude/skills/agent-skill-creator
-
-     For VS Code Copilot:
-       git clone https://github.com/FrancyJGLisboa/agent-skill-creator.git .github/skills/agent-skill-creator
-
-     For Cursor:
-       git clone https://github.com/FrancyJGLisboa/agent-skill-creator.git .cursor/rules/agent-skill-creator
-
-   STEP 2: Clone the team registry (one time)
-
-     git clone <registry-repo-url> ~/{team}-skills-registry
-
-   STEP 3: Create a skill from any workflow you do repeatedly
-
-     Open your IDE chat and type:
-       /agent-skill-creator Every week I pull sales data and generate a report
-
-   STEP 4: Publish your skill to the team registry
-
-     python3 scripts/skill_registry.py publish ./my-skill/ --registry ~/{team}-skills-registry --tags tag1,tag2
-     cd ~/{team}-skills-registry && git add -A && git commit -m "Add my-skill" && git push
-
-   STEP 5: Install a colleague's skill
-
-     git pull (inside ~/{team}-skills-registry to get latest)
-     python3 scripts/skill_registry.py list --registry ~/{team}-skills-registry
-     python3 scripts/skill_registry.py search "sales" --registry ~/{team}-skills-registry
-     python3 scripts/skill_registry.py install sales-report-skill --registry ~/{team}-skills-registry
-
-   ──────────────────────────────────────────────
-   ```
-
-**When to offer registry setup:**
-- User mentions "team", "organization", "department", "colleagues", "company"
-- User asks about sharing or distributing skills at scale
-- User is an AI consultant or admin setting up infrastructure for others
-
-**When NOT to offer:**
-- User is creating a single personal skill
-- A registry already exists (check for `~/team-skills-registry` or similar)
-
-The registry is a git repo. Version history, access control, and review workflows come free from GitHub/GitLab. No servers, no databases, no new tools.
-
-See `references/pipeline-phases.md` for detailed Phase 5 instructions.
-
-### Update Check
-
-When loading this skill, silently check if the local copy is behind the remote. Run:
-
-```bash
-cd <skill-install-dir> && git rev-parse HEAD 2>/dev/null
-cd <skill-install-dir> && git ls-remote origin HEAD 2>/dev/null | cut -f1
-```
-
-If both commands succeed and the hashes differ, mention to the user:
-"A newer version of agent-skill-creator is available. Run `git pull` in <path> to update."
-
-Do not block or interrupt for this. If either command fails (no git, no network, not a git repo), skip silently.
+Read `references/distribution-guide.md` for the git/`gh`/`glab` procedure, the platform-detection fallback, the shareable one-liner template, team-registry setup, and the update-check flow.
 
 ### Generated SKILL.md Format
 
@@ -698,46 +387,17 @@ See `references/architecture-guide.md` for detailed decision framework.
 
 Generated skills work across 17 tools in 3 tiers. Every generated skill outputs both **SKILL.md** (skill definition, ~15 tools) and **AGENTS.md** (instruction file, ~15 tools) to maximize reach.
 
-### Tier 1 — Native SKILL.md (reads directly, no conversion)
+- **Tier 1 — native SKILL.md** (12 tools: Claude Code, Copilot, Codex, Gemini, Kiro, Goose, OpenCode, Cline, Roo, Kilo, Factory, Antigravity). Installed as-is, no conversion.
+- **Tier 2 — auto-adapted** (Cursor `.mdc`, Windsurf and Trae `.md` rules, Junie `guidelines.md`). `install.sh` rewrites SKILL.md into the native format.
+- **Tier 3 — manual integration** (Zed, Augment, Aider, Continue.dev). The user copies the body into the tool's own config file.
 
-| Platform | Native Global Path | Native Project Path | Command |
-|----------|-------------------|--------------------|---------|
-| Claude Code | `~/.claude/skills/` | `.claude/skills/` | `./install.sh` |
-| GitHub Copilot | `~/.copilot/skills/` | `.github/skills/` | `./install.sh --platform copilot` |
-| Codex CLI | `~/.agents/skills/` | `.agents/skills/` | `./install.sh --platform codex` |
-| Gemini CLI | `~/.gemini/skills/` | `.gemini/skills/` | `./install.sh --platform gemini` |
-| Kiro | `~/.kiro/skills/` | `.kiro/skills/` | `./install.sh --platform kiro` |
-| Goose | `~/.config/goose/skills/` | — | `./install.sh --platform goose` |
-| OpenCode | `~/.config/opencode/skills/` | `.opencode/skills/` | `./install.sh --platform opencode` |
-| Cline | `~/.cline/skills/` | `.clinerules/skills/` | `./install.sh --platform cline` |
-| Roo Code | `~/.roo/skills/` | `.roo/skills/` | `./install.sh --platform roo-code` |
-| Kilo Code | `~/.kilocode/skills/` | `.kilocode/skills/` | `./install.sh --platform kilo-code` |
-| Factory Droid | `~/.factory/skills/` | `.factory/skills/` | `./install.sh --platform factory` |
-| Antigravity | — | `.agent/skills/` | `./install.sh --platform antigravity` |
+`scripts/platforms.py` is the canonical registry of all 17 platforms and their paths; the installers are checked against it in CI.
 
-### Tier 2 — Auto-adapted (installer converts SKILL.md to native format)
-
-| Platform | Native Format | Adaptation | Install Path | Command |
-|----------|--------------|------------|-------------|---------|
-| Cursor | `.mdc` | Generates `.mdc` with `alwaysApply`/`globs` frontmatter | `.cursor/skills/` (project only, no global) | `./install.sh --platform cursor` |
-| Windsurf | `.md` rules | Generates plain `.md` rule (6K char limit per file) | `.windsurf/rules/` (project) or `~/.codeium/windsurf/` (global) | `./install.sh --platform windsurf` |
-| Trae | `.md` rules | Generates plain `.md` with `type:` frontmatter | `.trae/rules/` | `./install.sh --platform trae` |
-| Junie | `guidelines.md` | Extracts body as plain markdown | `.junie/skills/` | `./install.sh --platform junie` |
-
-### Tier 3 — Manual integration
-
-| Platform | Config File | Instructions |
-|----------|------------|-------------|
-| Zed | `.rules` | Copy SKILL.md body into `.rules` file |
-| Augment | `.augment/rules/` | Copy as `.md` with `type: Always` frontmatter |
-| Aider | `CONVENTIONS.md` | Copy SKILL.md body into CONVENTIONS.md |
-| Continue.dev | `.continue/rules/` | Copy as `.md` with Continue frontmatter |
+Read `references/cross-platform-guide.md` for the per-platform path tables, install commands, and adaptation rules.
 
 ### Companion AGENTS.md
 
-Every generated skill also outputs an `AGENTS.md` file alongside SKILL.md. This extends reach to tools that prioritize AGENTS.md over SKILL.md (Codex CLI, Augment, Continue.dev, Zed, and others). The AGENTS.md contains the skill's purpose, activation triggers, and usage instructions in the AAIF-governed format.
-
-See `references/cross-platform-guide.md` for full platform details.
+Every generated skill also outputs an `AGENTS.md` alongside SKILL.md, extending reach to tools that prioritize it over SKILL.md (Codex CLI, Augment, Continue.dev, Zed). It carries the skill's purpose, activation triggers, usage, and its `## Gotchas` entries in full — those tools never open SKILL.md.
 
 ## Validation and Security
 
@@ -754,59 +414,25 @@ python3 scripts/validate.py path/to/skill/
 python3 scripts/security_scan.py path/to/skill/
 ```
 
-## Export System
+## Other Front Doors
 
-Package skills for distribution:
+Each of these is a mode of the same factory, documented in full in its own reference.
+
+| Mode | Trigger | Read |
+|---|---|---|
+| **Export** | "export this skill for Cursor" | `references/export-guide.md` |
+| **Templates** | a domain with a prebuilt blueprint (financial, climate, e-commerce) | `references/templates-guide.md` |
+| **Multi-agent suite** | "create a financial analysis suite with 4 agents" | `references/multi-agent-guide.md` |
+| **Interactive wizard** | "walk me through creating..." | `references/interactive-mode.md` |
 
 ```bash
-# Export for all platforms
-python3 scripts/export_utils.py path/to/skill/
-
-# Desktop/Web package only
-python3 scripts/export_utils.py path/to/skill/ --variant desktop
-
-# API package only
-python3 scripts/export_utils.py path/to/skill/ --variant api
+python3 scripts/export_utils.py path/to/skill/                    # all platforms
+python3 scripts/export_utils.py path/to/skill/ --variant desktop  # or: api
 ```
-
-See `references/export-guide.md` for full export documentation.
-
-## Template-Based Creation
-
-Pre-built templates for common domains:
-
-- **Financial Analysis**: Alpha Vantage/Yahoo Finance, fundamental + technical analysis
-- **Climate Analysis**: Open-Meteo/NOAA, anomalies + trends + seasonal patterns
-- **E-commerce Analytics**: Google Analytics/Stripe/Shopify, traffic + revenue + cohorts
-
-See `references/templates-guide.md` for template details and customization.
-
-## Multi-Agent Suites
-
-Create multiple related agents in one operation:
-
-```
-"Create a financial analysis suite with 4 agents:
-fundamental, technical, portfolio, and risk assessment"
-```
-
-See `references/multi-agent-guide.md` for suite creation docs.
-
-## Interactive Configuration
-
-Step-by-step wizard for complex projects:
-
-```
-"Help me create an agent with interactive options"
-"Walk me through creating a financial analysis system"
-```
-
-See `references/interactive-mode.md` for wizard documentation.
 
 ## Learning & Evolution
 
-Every generated skill ships its own learning loop — the eval harness plus a
-self-maintenance command:
+Every generated skill ships its own learning loop — the eval harness plus a self-maintenance command:
 
 - `run_evals.py --rollout` runs the skill on its golden inputs and scores real output
 - `--promote` captures first-green baselines; later runs are compared against them (regression gate)
@@ -814,9 +440,7 @@ self-maintenance command:
 - A `"split": "test"` holdout case is scored only at release, never fed to an optimization loop
 - `evolve.py` runs staleness/dependency/drift checks + the rollout in one command; every failure appends its raw evidence to the skill's `EVOLUTION.md`, which feeds a regenerate pass
 
-Read `references/agentdb-integration.md` as a design sketch only — it describes a
-future episodic learning layer that is NOT implemented; never present it as
-current behavior.
+Read `references/agentdb-integration.md` as a design sketch only — it describes a future episodic learning layer that is NOT implemented; never present it as current behavior.
 
 ## Quality Standards
 
@@ -858,10 +482,14 @@ The `-skill` suffix also serves as a signal to the agent: when it sees a repo or
 
 ## Reference Files
 
-| File | Contents |
+Read these on demand — each one when its moment arrives, not upfront.
+
+| File | When to read it |
 |------|----------|
 | `references/spec-ideation.md` | Phase 0 front door: turn vague input / "give me a skill idea" into a grounded, skill-shaped spec |
 | `references/mcp-audit.md` | `--mcp-audit` front door: vendor MCP server → capability map, ranked buildable skills, not-buildable list with named gaps |
+| `references/skill-audit.md` | `--audit` front door: the four audit questions, verdict rules, and how to report partial coverage on a skill you did not write |
+| `references/distribution-guide.md` | After the gates pass: platform detection table and native paths, share-with-team procedure (`gh`/`glab`), team registry setup, update check |
 | `references/pipeline-phases.md` | Detailed Phase 1-5 instructions |
 | `references/architecture-guide.md` | Simple vs Suite decision, refactoring, cross-component communication, versioning |
 | `references/templates-guide.md` | Template-based creation |

--- a/references/distribution-guide.md
+++ b/references/distribution-guide.md
@@ -1,0 +1,302 @@
+# Distribution: install, share, register, update
+
+Everything that happens **after** a skill passes its gates. Read this when you
+have just built a skill and are installing it, when the user wants to share one
+with their team, or when setting up a team registry.
+
+The factory's SKILL.md carries the decisions; this file carries the paths,
+procedures, and message templates they need.
+
+---
+
+## Auto-Install After Creation
+
+After the skill passes validation and security scan, install it immediately on the user's current platform. Do not ask the user to run `install.sh` manually — you are already running inside their environment and can detect their platform.
+
+**This path is for skills the factory just built.** A skill that came from anywhere else — a download, a colleague, a registry, a repo — must clear `--audit` first (see above). Auto-install never runs on an unscanned imported skill: the scan is what makes the install safe, and a skill this factory did not produce has not been scanned yet.
+
+**Detection logic** (check in order, install to each tool's **native** path):
+
+```
+~/.claude/              exists → Claude Code         → ~/.claude/skills/
+~/.copilot/             exists → GitHub Copilot CLI  → ~/.copilot/skills/
+.github/                exists → VS Code Copilot     → .github/skills/ (project)
+.cursor/                exists → Cursor              → .cursor/skills/ (project only, no global path)
+~/.codeium/windsurf/    exists → Windsurf            → ~/.codeium/windsurf/skills/ (global) + format adapt
+.windsurf/              exists → Windsurf            → .windsurf/rules/ (project) + format adapt
+.clinerules/ or ~/.cline/ exists → Cline             → .clinerules/skills/ or ~/.cline/skills/
+~/.gemini/              exists → Gemini CLI          → ~/.gemini/skills/
+.kiro/                  exists → Kiro                → .kiro/skills/ (project)
+.trae/                  exists → Trae                → .trae/rules/ + format adapt (plain .md)
+.roo/                   exists → Roo Code            → .roo/skills/
+~/.config/goose/        exists → Goose               → ~/.config/goose/skills/
+~/.config/opencode/     exists → OpenCode            → ~/.config/opencode/skills/
+~/.agents/              exists → Universal           → ~/.agents/skills/
+```
+
+After installing to the native path, **also create a symlink at `~/.agents/skills/`** so the skill is discoverable by tools reading the universal path (Codex CLI, Gemini CLI, OpenCode, Goose, Cline, Roo Code).
+
+**Format adaptation**: For Tier 2 platforms (Cursor, Windsurf, Trae), also generate the native format alongside SKILL.md:
+- **Cursor**: Generate `.mdc` file with `alwaysApply: true` and description from frontmatter
+- **Windsurf**: Generate plain `.md` rule, respect 6,000 char per-file limit
+- **Trae**: Generate plain `.md` rule with `type: Always` frontmatter
+
+**Install action**: Copy or symlink the generated skill directory into the platform's native skill path:
+
+```bash
+# Claude Code (user-level):
+cp -R ./sales-report-skill ~/.claude/skills/sales-report-skill
+
+# GitHub Copilot (user-level — Copilot's own path, not Claude's):
+cp -R ./sales-report-skill ~/.copilot/skills/sales-report-skill
+
+# GitHub Copilot (project-level):
+cp -R ./sales-report-skill .github/skills/sales-report-skill
+
+# Cursor (project-level ONLY — no global path exists):
+cp -R ./sales-report-skill .cursor/skills/sales-report-skill
+
+# Gemini CLI (native path):
+cp -R ./sales-report-skill ~/.gemini/skills/sales-report-skill
+```
+
+**After installing, tell the user exactly what to do next:**
+
+```
+Skill installed successfully.
+
+To use it, open a new session and type:
+
+  /sales-report-skill Generate the weekly report for the West region
+
+The skill is installed at: ~/.claude/skills/sales-report-skill
+```
+
+If you cannot detect the platform, show the user how to run the install manually:
+
+```
+I couldn't auto-detect your platform. To install, run:
+
+  ./sales-report-skill/install.sh
+
+Or specify your platform:
+
+  ./sales-report-skill/install.sh --platform cursor
+
+Or install to all detected platforms at once:
+
+  ./sales-report-skill/install.sh --all
+
+Alternative (if npx is available):
+
+  npx skills add ./sales-report-skill
+```
+
+The `install.sh` inside the skill handles auto-detection, platform-specific paths, project vs user level, dry-run mode, and post-install activation instructions. It is the fallback for users who receive the skill as a package (not created in their current session).
+
+The generated skill must be a self-contained package that anyone can install with `git clone` or `./install.sh` and invoke with `/skill-name` — the same way agent-skill-creator itself works.
+
+## Share With Your Team (Post-Creation)
+
+After installing the skill locally, always ask:
+
+```
+Want to share this skill with your team so they can install it too?
+```
+
+Corporate users don't know what a registry is, how to `git push`, or what `skill_registry.py` does. They just want their colleague to have the same skill. You handle everything.
+
+**If the user says yes, do all of this automatically:**
+
+1. **Initialize a git repo** inside the generated skill directory:
+   ```bash
+   cd ./sales-report-skill
+   git init
+   git add -A
+   git commit -m "feat: Initial skill — sales-report-skill"
+   ```
+
+2. **Detect the team's git platform** and create a remote repo:
+
+   Check which CLI tools are available and authenticated:
+
+   ```
+   gh auth status    → GitHub (github.com or GitHub Enterprise)
+   glab auth status  → GitLab (gitlab.com or self-hosted)
+   ```
+
+   **If `gh` is available (GitHub):**
+   ```bash
+   gh repo create sales-report-skill --public --source=. --push
+   gh repo edit --add-topic agent-skill
+   ```
+
+   **If `glab` is available (GitLab):**
+   ```bash
+   glab repo create sales-report-skill --public --defaultBranch main
+   git remote add origin <returned-url>
+   git push -u origin main
+   glab repo edit --topic agent-skill
+   ```
+
+   The `agent-skill` topic makes skills discoverable across the org. Teams can search `topic:agent-skill` on GitHub or filter by topic on GitLab to find all shared skills.
+
+   **If both are available**, check the existing git remotes in the current project to infer which platform the team uses. If the current project's `origin` points to `gitlab.com` or a GitLab instance, use `glab`. Otherwise default to `gh`.
+
+   **If neither is available**, tell the user:
+   ```
+   I can't create the repo automatically. To share this skill:
+   1. Create a new repo on GitHub or GitLab called "sales-report-skill"
+   2. Then run:
+      git remote add origin <repo-url>
+      git push -u origin main
+   3. Share the git clone link with your team
+   ```
+
+3. **Give the user a shareable one-liner** they can send to colleagues:
+   ```
+   Shared! Your colleagues can install it by pasting this in their terminal:
+
+     git clone <repo-url> ~/.claude/skills/sales-report-skill
+
+   Or for VS Code Copilot:
+
+     git clone <repo-url> .github/skills/sales-report-skill
+
+   Or for Cursor:
+
+     git clone <repo-url> .cursor/rules/sales-report-skill
+   ```
+
+   Use the actual repo URL from step 2 (GitHub or GitLab). The install pattern is identical regardless of git platform.
+
+4. **Optionally publish to the team registry** (if the agent-skill-creator registry is available):
+   ```bash
+   python3 scripts/skill_registry.py publish ./sales-report-skill/ --tags <auto-generated-tags>
+   ```
+
+The goal: the user who created the skill sends a one-liner to their colleague on Slack or Teams. The colleague pastes it. Done. No registry knowledge, no `skill_registry.py`, no understanding of the spec. Just `git clone` and it works — whether the team uses GitHub or GitLab.
+
+**If the user says no**, that's fine — the skill is already installed locally and working. They can always share later.
+
+## Set Up a Team Skill Registry
+
+When a user mentions a team, organization, or colleagues — or when they ask about sharing skills at scale — offer to create a **team skill registry**. This is a shared git repo that acts as the central catalog where all team members publish and install skills.
+
+This is the model for AI consultants enabling corporate teams:
+1. The consultant teaches each team member to install and use agent-skill-creator
+2. The consultant creates one shared `{team}-skills-registry` repo on GitHub/GitLab
+3. Each team member creates skills from their own workflows using `/agent-skill-creator`
+4. Each member publishes to the shared registry
+5. Other members browse, search, and install from that same registry
+
+The consultant delivers **knowledge and infrastructure**, not skills. The team creates the skills themselves — they know their workflows better than anyone.
+
+```
+Want me to set up a shared skill registry for your team? It's a single
+repo where everyone publishes their skills and anyone can browse and
+install them — like an internal app store for agent skills.
+```
+
+**If the user says yes, do all of this automatically:**
+
+1. **Ask for the team or org name** to use in the registry name (e.g., "engineering", "acme-corp"):
+
+2. **Initialize the registry**:
+   ```bash
+   mkdir -p ~/{team}-skills-registry
+   python3 scripts/skill_registry.py init --registry ~/{team}-skills-registry --name "{Team Name} Skills"
+   ```
+
+3. **Create a remote repo** (same GitHub/GitLab detection as skill sharing):
+   ```bash
+   cd ~/{team}-skills-registry
+   git init && git add -A && git commit -m "feat: Initialize {team} skill registry"
+
+   # GitHub
+   gh repo create {team}-skills-registry --private --source=. --push
+   gh repo edit --add-topic agent-skill-registry
+
+   # Or GitLab
+   glab repo create {team}-skills-registry --private --defaultBranch main
+   git remote add origin <url> && git push -u origin main
+   ```
+
+   The registry repo should be **private** by default (internal to the org). The team admin controls who has access via GitHub/GitLab repo permissions.
+
+4. **If a skill was just created**, publish it as the first entry:
+   ```bash
+   python3 scripts/skill_registry.py publish ./sales-report-skill/ --registry ~/{team}-skills-registry --tags sales,reports
+   cd ~/{team}-skills-registry && git add -A && git commit -m "feat: Add sales-report-skill" && git push
+   ```
+
+5. **Give the user a team onboarding guide** they can share on Slack, Teams, or email:
+
+   ```
+   Registry is live! Share this with your team:
+
+   ──────────────────────────────────────────────
+   TEAM SKILL REGISTRY — Quick Start
+   ──────────────────────────────────────────────
+
+   STEP 1: Install agent-skill-creator (one time)
+
+     git clone https://github.com/FrancyJGLisboa/agent-skill-creator.git ~/.claude/skills/agent-skill-creator
+
+     For VS Code Copilot:
+       git clone https://github.com/FrancyJGLisboa/agent-skill-creator.git .github/skills/agent-skill-creator
+
+     For Cursor:
+       git clone https://github.com/FrancyJGLisboa/agent-skill-creator.git .cursor/rules/agent-skill-creator
+
+   STEP 2: Clone the team registry (one time)
+
+     git clone <registry-repo-url> ~/{team}-skills-registry
+
+   STEP 3: Create a skill from any workflow you do repeatedly
+
+     Open your IDE chat and type:
+       /agent-skill-creator Every week I pull sales data and generate a report
+
+   STEP 4: Publish your skill to the team registry
+
+     python3 scripts/skill_registry.py publish ./my-skill/ --registry ~/{team}-skills-registry --tags tag1,tag2
+     cd ~/{team}-skills-registry && git add -A && git commit -m "Add my-skill" && git push
+
+   STEP 5: Install a colleague's skill
+
+     git pull (inside ~/{team}-skills-registry to get latest)
+     python3 scripts/skill_registry.py list --registry ~/{team}-skills-registry
+     python3 scripts/skill_registry.py search "sales" --registry ~/{team}-skills-registry
+     python3 scripts/skill_registry.py install sales-report-skill --registry ~/{team}-skills-registry
+
+   ──────────────────────────────────────────────
+   ```
+
+**When to offer registry setup:**
+- User mentions "team", "organization", "department", "colleagues", "company"
+- User asks about sharing or distributing skills at scale
+- User is an AI consultant or admin setting up infrastructure for others
+
+**When NOT to offer:**
+- User is creating a single personal skill
+- A registry already exists (check for `~/team-skills-registry` or similar)
+
+The registry is a git repo. Version history, access control, and review workflows come free from GitHub/GitLab. No servers, no databases, no new tools.
+
+See `references/pipeline-phases.md` for detailed Phase 5 instructions.
+
+## Update Check
+
+When loading this skill, silently check if the local copy is behind the remote. Run:
+
+```bash
+cd <skill-install-dir> && git rev-parse HEAD 2>/dev/null
+cd <skill-install-dir> && git ls-remote origin HEAD 2>/dev/null | cut -f1
+```
+
+If both commands succeed and the hashes differ, mention to the user:
+"A newer version of agent-skill-creator is available. Run `git pull` in <path> to update."
+
+Do not block or interrupt for this. If either command fails (no git, no network, not a git repo), skip silently.
+

--- a/references/skill-audit.md
+++ b/references/skill-audit.md
@@ -1,0 +1,64 @@
+# `--audit` — vetting a skill you did not write
+
+The front door for a skill arriving from outside: a download, a colleague's
+folder, a registry entry, a repo. The deliverable is a verdict on whether it is
+safe to install, not a build.
+
+Read this when the user points at a skill they did not create and asks whether to
+trust it. For skills the factory itself produced, the Phase 5 gates already cover
+this ground and auto-install proceeds normally.
+
+---
+
+When the user points at a skill **they did not create** — a download, a colleague's
+folder, a registry entry, anything arriving from outside — the deliverable is a
+verdict on whether it is safe to install, not a build.
+
+This matters because a skill is not a document. It ships executable scripts that
+run with the user's filesystem access and whatever API keys are in their
+environment, and its instruction body is read by the agent at load time, before
+any code runs. Installing one is taking a dependency on a stranger's software.
+Treat it the way you would treat an unfamiliar package.
+
+Run both gates and report what they found:
+
+```bash
+python3 scripts/validate.py <path>       # structure, naming, frontmatter
+python3 scripts/security_scan.py <path>  # the part that matters here
+```
+
+Then answer these four questions in plain language. Do not just print the scanner
+output — the user asked whether to trust it.
+
+1. **What does it reach?** `security_scan.py` cross-checks every network endpoint
+   found in `scripts/` against the hosts declared in the SKILL.md frontmatter.
+   An undeclared endpoint is the finding that matters most: the skill contacts
+   something its own documentation does not mention.
+2. **What can it read or write?** Walk the scripts for filesystem paths and
+   environment-variable reads. A skill that reads `~/.aws/credentials` or
+   `os.environ` broadly, without a stated reason, is the thing to flag.
+3. **Does the instruction body try to steer the agent?** The scanner flags
+   override phrasing, concealment and exfiltration directives, invisible or
+   bidirectional unicode, and long encoded blobs. Any hit here is more serious
+   than a code finding — it executes on load, and hidden unicode exists
+   specifically to survive human review.
+4. **Who wrote it, and does the code match the description?** Compare what the
+   frontmatter claims with what the scripts actually do. A mismatch is a finding
+   even when nothing pattern-matches.
+
+## Verdict rules
+
+- Any **high-severity** finding → report as unsafe to install, name the finding
+  and its file:line, and stop. Do not install it, and do not offer a workaround.
+- Medium or low findings → report them plainly and let the user decide, saying
+  which ones would matter given what the skill claims to do.
+- A clean scan is **not proof the skill is safe**. It means no known pattern
+  matched. Say so, and say what you actually read. A scanner cannot recognize
+  intent, and a skill can do harm with entirely ordinary-looking code.
+- If the skill's scripts are too large to read in full, say which files you read
+  and which you did not, rather than implying whole-package coverage.
+
+Anything imported from outside goes through this before it is installed —
+including registry installs, which now re-scan at install time rather than
+trusting the catalog's cached verdict.
+


### PR DESCRIPTION
The factory told every generated skill to keep its body under 500 lines and move detail to `references/` — then shipped an **877-line body itself**. `validate.py` warned on it every run. A tool whose whole pitch is enforcing standards shouldn't be its own top offender.

**877 → 484 body lines**, using the mechanism the docs prescribe: keep the decisions and directives in SKILL.md, move the tables, path lists, and message templates to references loaded on demand.

## Two new references

| File | Lines | What moved |
|---|---|---|
| `references/distribution-guide.md` | 302 | The 14-row platform detection table, native paths, confirmation and fallback message templates, the share-with-team `gh`/`glab` procedure, team registry setup, update check |
| `references/skill-audit.md` | 64 | The four `--audit` questions, verdict rules, partial-coverage reporting |

Both are things that matter at exactly one moment and are never needed to route a request — the definition of progressive disclosure. `skill-audit.md` mirrors how `--mcp-audit` already works: a short front-door stub in SKILL.md, the procedure in a reference.

## Compressed in place

- **Cross-Platform Support** — the three tier tables were already duplicated *verbatim* in `references/cross-platform-guide.md`. SKILL.md now carries the tier summary and points at the canonical copy, and at `scripts/platforms.py`, which CI already checks the installers against. Removing them lost nothing.
- **Export / templates / multi-agent / interactive** — four sections that were each three lines of prose plus a pointer, collapsed into one "Other Front Doors" table.
- Trimmed two redundant trigger examples.

## Nothing was lost

Every directive survives in SKILL.md: auto-install immediately rather than asking the user to run `install.sh`, imported skills clear `--audit` first, always offer to share after installing.

I verified this by string-matching the distinctive content of every moved block against its new home — `gh repo create`, `glab repo create`, `~/.codeium/windsurf/`, `npx skills add`, `install.sh --all`, `alwaysApply`, `Junie`, `CONVENTIONS.md`, `~/.kilocode/skills/`, `Antigravity`, `hidden unicode`. All present.

## Verification

- **484 body lines** — no size warning from `validate.py` for the first time
- No Gotchas warning, no run-vs-read labeling warning
- 304 tests pass, `ruff check` clean
- The 4 remaining validator warnings are pre-existing and unrelated (`-skill` suffix, temporal metadata, `activation`, `provenance`)
- README Project Structure updated with both new files

Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)