### PR TITLE
fix: complete the creator's own frontmatter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -12,9 +12,20 @@ description: >-
   template-based creation, interactive configuration, cross-platform export,
   spec validation, and security auditing of third-party skills before install.
 license: MIT
+activation: /agent-skill-creator
 metadata:
   author: Francy Lisboa Charuto
   version: 6.0.0
+  created: 2025-10-18
+  last_reviewed: 2026-08-11
+  review_interval_days: 180
+provenance:
+  maintainer: Francy Lisboa Charuto
+  version: 6.0.0
+  created: 2025-10-18
+  source_references:
+    - https://github.com/FrancyJGLisboa/agent-skill-creator
+    - https://agentskills.io
 compatibility: >-
   Works on all platforms supporting the Agent Skills Open Standard (SKILL.md):
   Claude Code, GitHub Copilot CLI, VS Code Copilot, Cursor, Windsurf, Cline,


### PR DESCRIPTION
Clears the three genuine validator warnings the creator had been carrying since before today's work.

| Field | Value | Why |
|---|---|---|
| `activation` | `/agent-skill-creator` | The namespace-enforcement field the factory requires of every skill it generates |
| `metadata.created` | `2025-10-18` | The repo's actual first commit, not a guess |
| `metadata.last_reviewed` | `2026-08-11` | Today |
| `metadata.review_interval_days` | `180` | Matches the bundled examples |
| `provenance` | maintainer, version, created, source_references | The shape `pipeline-phases.md` Step 8f prescribes for a standalone skill |

`staleness_check.py` now reports **FRESH** instead of having nothing to measure.

## Parser check

`skill_document.py` deliberately isn't a full YAML parser — it's hand-rolled to avoid a PyYAML dependency. I verified it handles the new nested `provenance` block and its `source_references` list: every field still resolves (`metadata.version`, `metadata.created`, `metadata.author`, `provenance.maintainer`, `activation`, `compatibility`), and export, plugin manifests, and the registry are unaffected.

## The one warning left, deliberately

```
[WARN] 'name' should end with '-skill' for discoverability (found: 'agent-skill-creator')
```

Left as-is. It's *accurate* — this skill genuinely doesn't end in `-skill`. But the suffix exists so teams can search `*-skill` to find installable skills in their org, and this repo is the factory rather than one of its products.

Renaming would break all 17 native install paths, the plugin manifests, and the marketplace entry — to satisfy a convention it exists to enforce on others. Special-casing the validator to exempt one name by string match would be worse: the check would then lie about what it enforces.

## Verification

- 304 tests pass, `ruff check` clean
- `validate.py .` → VALID, one warning (down from four)
- `staleness_check.py .` → FRESH, exit 0
- `export_utils.py --variant desktop` and both plugin manifests still resolve `name` and `version`

One file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)