### PR TITLE
feat: capture corrections from use into a skill's gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,18 @@ python3 scripts/evolve.py --judge   # also grade llm-judge criteria
 # Any failure appends its raw evidence to the skill's EVOLUTION.md
 ```
 
+### Corrections from use
+
+Automated checks catch dates, reachability, and output drift. They cannot catch the knowledge that only exists in someone's head — the region that files late, the code that means something local, the month the process runs differently.
+
+That knowledge is not obtainable by asking up front. People can't describe a process they run from muscle memory, which is why this factory reads artifacts instead of interviewing. But the same person recognizes a wrong output instantly. So capture it at that moment:
+
+```bash
+python3 scripts/evolve.py --correct "the West region files late, so Friday exports are short"
+```
+
+The sentence goes verbatim into `EVOLUTION.md` as evidence and into the skill's `## Gotchas`, so the next run already knows. A skill's gotchas should grow over its life — a section that never grows means nobody ever told it anything.
+
 The creator-repo commands below work too (for skills built before the toolkit shipped, or ad-hoc checks). Three layers, each opt-in:
 
 **Review tracking** — Every skill can declare when it was last reviewed and how often it should be. The staleness checker compares these dates and flags overdue skills. Skills without explicit dates fall back to the last git commit date on SKILL.md.

--- a/SKILL.md
+++ b/SKILL.md
@@ -450,6 +450,9 @@ Every generated skill ships its own learning loop — the eval harness plus a se
 - `--judge` grades `llm-judge` criteria with a judge pinned in the spec (model + temperature); a known-bad canary must fail every criterion or the judge run is invalid
 - A `"split": "test"` holdout case is scored only at release, never fed to an optimization loop
 - `evolve.py` runs staleness/dependency/drift checks + the rollout in one command; every failure appends its raw evidence to the skill's `EVOLUTION.md`, which feeds a regenerate pass
+- `evolve.py --correct "<what it got wrong>"` captures the one thing no check can derive: a correction from someone using the skill. It writes the sentence verbatim to `EVOLUTION.md` and adds it to `## Gotchas`
+
+**Tell the user about `--correct` when you hand over a skill.** The deepest expertise in any workflow is never stated up front — people cannot describe a process they run from muscle memory, which is why this factory reads artifacts instead of interviewing. But the same person recognizes a wrong output instantly. `--correct` is the capture point for that moment, and it is how a skill's `## Gotchas` accumulates real knowledge over its life instead of being frozen at whatever could be extracted on day one.
 
 Read `references/agentdb-integration.md` as a design sketch only — it describes a future episodic learning layer that is NOT implemented; never present it as current behavior.
 

--- a/references/examples/pr-blocker-summarizer/scripts/evolve.py
+++ b/references/examples/pr-blocker-summarizer/scripts/evolve.py
@@ -5,9 +5,10 @@ Evolve loop shipped inside every generated skill as scripts/evolve.py.
 One command that closes the maintenance loop from the skill's own root:
 
     python3 scripts/evolve.py            # detect -> record -> re-verify
-    python3 scripts/evolve.py --judge    # also grade llm-judge criteria (needs ANTHROPIC_API_KEY)
+    python3 scripts/evolve.py --judge    # also grade llm-judge criteria
+    python3 scripts/evolve.py --correct "<what the skill got wrong>"
 
-Steps:
+Steps (default mode):
   1. staleness_check --check-deps --check-drift --record
      (review-interval, dependency health, schema drift; failures append raw
      evidence to EVOLUTION.md)
@@ -15,21 +16,150 @@ Steps:
      (runs the skill on its golden inputs; command checks + baseline regression
      gate + optional pinned judge; failures append raw evidence to EVOLUTION.md)
 
+`--correct` is a different kind of input, and the most valuable one this loop
+takes. Steps 1 and 2 catch what a machine can check: dates, reachability, output
+drift. They cannot catch the class of knowledge that only exists in someone's
+head -- the region that files late, the code that means something local, the
+month the process runs differently.
+
+That knowledge is not obtainable by asking up front. People cannot articulate a
+workflow they run from muscle memory, which is why this factory reads artifacts
+instead of interviewing. But the same person who could not describe the rule will
+recognize its violation instantly, the moment the skill produces something wrong.
+`--correct` is the capture point for that moment: it takes the sentence they would
+have said out loud, writes it verbatim to EVOLUTION.md as evidence, and adds it to
+the skill's `## Gotchas` so the next run already knows.
+
 Exit codes:
-    0 - fresh and green
+    0 - fresh and green (or: correction recorded)
     1 - one or more steps failed; EVOLUTION.md holds the evidence
+    2 - bad usage
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+GOTCHAS_HEADING = re.compile(r"^([ \t]{0,3})(#{1,6})[ \t]+gotchas\b.*$", re.IGNORECASE | re.MULTILINE)
+# A placeholder body meaning "there are none yet" -- replaced rather than appended to.
+NONE_KNOWN = re.compile(r"^\s*(none known|none|n/a)\.?\s*$", re.IGNORECASE)
+# Sections a Gotchas block should precede when one has to be created from scratch.
+FALLBACK_ANCHORS = ("## Keywords", "## Usage Examples", "## References", "## Anti-goals")
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_correction(skill_dir: Path, text: str) -> list[str]:
+    """Write a user correction to EVOLUTION.md and the SKILL.md Gotchas section.
+
+    Verbatim on purpose. The wording a user reaches for when something is wrong
+    carries detail a paraphrase drops, and this runs unattended -- rewriting it
+    into the wrong-assumption/real-behavior house style is a judgment call for
+    whoever next edits the skill, not for this script.
+
+    Args:
+        skill_dir: The skill's root (the directory holding SKILL.md).
+        text: The correction, as the user phrased it.
+
+    Returns:
+        Human-readable lines describing what changed, for printing.
+
+    Raises:
+        ValueError: If the text is blank or SKILL.md is missing.
+    """
+    text = " ".join(text.split())
+    if not text:
+        raise ValueError("correction text is empty")
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise ValueError(f"SKILL.md not found in {skill_dir}")
+
+    stamp = _utc_stamp()
+    done: list[str] = []
+
+    # 1. EVOLUTION.md -- the audit trail. Append-only, never rewritten.
+    evolution = skill_dir / "EVOLUTION.md"
+    if not evolution.exists():
+        evolution.write_text(
+            "# Evolution log\n\nAppended automatically by scripts/run_evals.py "
+            "(and scripts/evolve.py) when a check fails. Each entry is the raw "
+            "evidence for a fix/regenerate step.\n\n",
+            encoding="utf-8",
+        )
+    with evolution.open("a", encoding="utf-8") as fh:
+        fh.write(
+            f"## {stamp} — correction from use\n\n"
+            f"Reported while using the skill, not caught by any automated check.\n\n"
+            f"> {text}\n\n"
+            f"Added to the SKILL.md `## Gotchas` section.\n\n"
+        )
+    done.append(f"EVOLUTION.md  <- correction recorded ({stamp})")
+
+    # 2. SKILL.md ## Gotchas -- the part the agent actually reads on the next run.
+    content = skill_md.read_text(encoding="utf-8")
+    bullet = f"- {text}"
+    match = GOTCHAS_HEADING.search(content)
+
+    if match:
+        level = len(match.group(2))
+        body_start = match.end()
+        # The section runs to the next heading at the same level or higher.
+        following = re.compile(rf"^[ \t]{{0,3}}#{{1,{level}}}[ \t]+", re.MULTILINE)
+        nxt = following.search(content, body_start)
+        body_end = nxt.start() if nxt else len(content)
+        body = content[body_start:body_end]
+
+        if all(NONE_KNOWN.match(ln) or not ln.strip() for ln in body.splitlines()):
+            new_body = f"\n\n{bullet}\n\n"          # replace the placeholder
+            note = "replaced 'None known'"
+        else:
+            new_body = body.rstrip("\n") + f"\n{bullet}\n\n"
+            note = "appended"
+        content = content[:body_start] + new_body + content[body_end:]
+    else:
+        section = f"## Gotchas\n\n{bullet}\n\n"
+        anchor = next((a for a in FALLBACK_ANCHORS if f"\n{a}" in content), None)
+        if anchor:
+            content = content.replace(f"\n{anchor}", f"\n{section}{anchor}", 1)
+        else:
+            content = content.rstrip("\n") + f"\n\n{section}"
+        note = "created the section"
+
+    skill_md.write_text(content, encoding="utf-8")
+    done.append(f"SKILL.md      <- ## Gotchas ({note})")
+    return done
 
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
     root = Path(__file__).resolve().parent.parent
+
+    if "--correct" in args:
+        index = args.index("--correct")
+        text = " ".join(args[index + 1:])
+        if not text.strip():
+            print(
+                'usage: python3 scripts/evolve.py --correct "<what the skill got wrong>"',
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            for line in record_correction(root, text):
+                print(line)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print("\nnext: run scripts/evolve.py to re-verify, and reword the entry in the")
+        print("house style (wrong assumption -> real behavior) next time you edit the skill")
+        return 0
+
     judge = ["--judge"] if "--judge" in args else []
 
     steps = [

--- a/references/examples/stock-analyzer/scripts/evolve.py
+++ b/references/examples/stock-analyzer/scripts/evolve.py
@@ -5,9 +5,10 @@ Evolve loop shipped inside every generated skill as scripts/evolve.py.
 One command that closes the maintenance loop from the skill's own root:
 
     python3 scripts/evolve.py            # detect -> record -> re-verify
-    python3 scripts/evolve.py --judge    # also grade llm-judge criteria (needs ANTHROPIC_API_KEY)
+    python3 scripts/evolve.py --judge    # also grade llm-judge criteria
+    python3 scripts/evolve.py --correct "<what the skill got wrong>"
 
-Steps:
+Steps (default mode):
   1. staleness_check --check-deps --check-drift --record
      (review-interval, dependency health, schema drift; failures append raw
      evidence to EVOLUTION.md)
@@ -15,21 +16,150 @@ Steps:
      (runs the skill on its golden inputs; command checks + baseline regression
      gate + optional pinned judge; failures append raw evidence to EVOLUTION.md)
 
+`--correct` is a different kind of input, and the most valuable one this loop
+takes. Steps 1 and 2 catch what a machine can check: dates, reachability, output
+drift. They cannot catch the class of knowledge that only exists in someone's
+head -- the region that files late, the code that means something local, the
+month the process runs differently.
+
+That knowledge is not obtainable by asking up front. People cannot articulate a
+workflow they run from muscle memory, which is why this factory reads artifacts
+instead of interviewing. But the same person who could not describe the rule will
+recognize its violation instantly, the moment the skill produces something wrong.
+`--correct` is the capture point for that moment: it takes the sentence they would
+have said out loud, writes it verbatim to EVOLUTION.md as evidence, and adds it to
+the skill's `## Gotchas` so the next run already knows.
+
 Exit codes:
-    0 - fresh and green
+    0 - fresh and green (or: correction recorded)
     1 - one or more steps failed; EVOLUTION.md holds the evidence
+    2 - bad usage
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+GOTCHAS_HEADING = re.compile(r"^([ \t]{0,3})(#{1,6})[ \t]+gotchas\b.*$", re.IGNORECASE | re.MULTILINE)
+# A placeholder body meaning "there are none yet" -- replaced rather than appended to.
+NONE_KNOWN = re.compile(r"^\s*(none known|none|n/a)\.?\s*$", re.IGNORECASE)
+# Sections a Gotchas block should precede when one has to be created from scratch.
+FALLBACK_ANCHORS = ("## Keywords", "## Usage Examples", "## References", "## Anti-goals")
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_correction(skill_dir: Path, text: str) -> list[str]:
+    """Write a user correction to EVOLUTION.md and the SKILL.md Gotchas section.
+
+    Verbatim on purpose. The wording a user reaches for when something is wrong
+    carries detail a paraphrase drops, and this runs unattended -- rewriting it
+    into the wrong-assumption/real-behavior house style is a judgment call for
+    whoever next edits the skill, not for this script.
+
+    Args:
+        skill_dir: The skill's root (the directory holding SKILL.md).
+        text: The correction, as the user phrased it.
+
+    Returns:
+        Human-readable lines describing what changed, for printing.
+
+    Raises:
+        ValueError: If the text is blank or SKILL.md is missing.
+    """
+    text = " ".join(text.split())
+    if not text:
+        raise ValueError("correction text is empty")
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise ValueError(f"SKILL.md not found in {skill_dir}")
+
+    stamp = _utc_stamp()
+    done: list[str] = []
+
+    # 1. EVOLUTION.md -- the audit trail. Append-only, never rewritten.
+    evolution = skill_dir / "EVOLUTION.md"
+    if not evolution.exists():
+        evolution.write_text(
+            "# Evolution log\n\nAppended automatically by scripts/run_evals.py "
+            "(and scripts/evolve.py) when a check fails. Each entry is the raw "
+            "evidence for a fix/regenerate step.\n\n",
+            encoding="utf-8",
+        )
+    with evolution.open("a", encoding="utf-8") as fh:
+        fh.write(
+            f"## {stamp} — correction from use\n\n"
+            f"Reported while using the skill, not caught by any automated check.\n\n"
+            f"> {text}\n\n"
+            f"Added to the SKILL.md `## Gotchas` section.\n\n"
+        )
+    done.append(f"EVOLUTION.md  <- correction recorded ({stamp})")
+
+    # 2. SKILL.md ## Gotchas -- the part the agent actually reads on the next run.
+    content = skill_md.read_text(encoding="utf-8")
+    bullet = f"- {text}"
+    match = GOTCHAS_HEADING.search(content)
+
+    if match:
+        level = len(match.group(2))
+        body_start = match.end()
+        # The section runs to the next heading at the same level or higher.
+        following = re.compile(rf"^[ \t]{{0,3}}#{{1,{level}}}[ \t]+", re.MULTILINE)
+        nxt = following.search(content, body_start)
+        body_end = nxt.start() if nxt else len(content)
+        body = content[body_start:body_end]
+
+        if all(NONE_KNOWN.match(ln) or not ln.strip() for ln in body.splitlines()):
+            new_body = f"\n\n{bullet}\n\n"          # replace the placeholder
+            note = "replaced 'None known'"
+        else:
+            new_body = body.rstrip("\n") + f"\n{bullet}\n\n"
+            note = "appended"
+        content = content[:body_start] + new_body + content[body_end:]
+    else:
+        section = f"## Gotchas\n\n{bullet}\n\n"
+        anchor = next((a for a in FALLBACK_ANCHORS if f"\n{a}" in content), None)
+        if anchor:
+            content = content.replace(f"\n{anchor}", f"\n{section}{anchor}", 1)
+        else:
+            content = content.rstrip("\n") + f"\n\n{section}"
+        note = "created the section"
+
+    skill_md.write_text(content, encoding="utf-8")
+    done.append(f"SKILL.md      <- ## Gotchas ({note})")
+    return done
 
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
     root = Path(__file__).resolve().parent.parent
+
+    if "--correct" in args:
+        index = args.index("--correct")
+        text = " ".join(args[index + 1:])
+        if not text.strip():
+            print(
+                'usage: python3 scripts/evolve.py --correct "<what the skill got wrong>"',
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            for line in record_correction(root, text):
+                print(line)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print("\nnext: run scripts/evolve.py to re-verify, and reword the entry in the")
+        print("house style (wrong assumption -> real behavior) next time you edit the skill")
+        return 0
+
     judge = ["--judge"] if "--judge" in args else []
 
     steps = [

--- a/references/examples/weekly-crm-report/scripts/evolve.py
+++ b/references/examples/weekly-crm-report/scripts/evolve.py
@@ -5,9 +5,10 @@ Evolve loop shipped inside every generated skill as scripts/evolve.py.
 One command that closes the maintenance loop from the skill's own root:
 
     python3 scripts/evolve.py            # detect -> record -> re-verify
-    python3 scripts/evolve.py --judge    # also grade llm-judge criteria (needs ANTHROPIC_API_KEY)
+    python3 scripts/evolve.py --judge    # also grade llm-judge criteria
+    python3 scripts/evolve.py --correct "<what the skill got wrong>"
 
-Steps:
+Steps (default mode):
   1. staleness_check --check-deps --check-drift --record
      (review-interval, dependency health, schema drift; failures append raw
      evidence to EVOLUTION.md)
@@ -15,21 +16,150 @@ Steps:
      (runs the skill on its golden inputs; command checks + baseline regression
      gate + optional pinned judge; failures append raw evidence to EVOLUTION.md)
 
+`--correct` is a different kind of input, and the most valuable one this loop
+takes. Steps 1 and 2 catch what a machine can check: dates, reachability, output
+drift. They cannot catch the class of knowledge that only exists in someone's
+head -- the region that files late, the code that means something local, the
+month the process runs differently.
+
+That knowledge is not obtainable by asking up front. People cannot articulate a
+workflow they run from muscle memory, which is why this factory reads artifacts
+instead of interviewing. But the same person who could not describe the rule will
+recognize its violation instantly, the moment the skill produces something wrong.
+`--correct` is the capture point for that moment: it takes the sentence they would
+have said out loud, writes it verbatim to EVOLUTION.md as evidence, and adds it to
+the skill's `## Gotchas` so the next run already knows.
+
 Exit codes:
-    0 - fresh and green
+    0 - fresh and green (or: correction recorded)
     1 - one or more steps failed; EVOLUTION.md holds the evidence
+    2 - bad usage
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+GOTCHAS_HEADING = re.compile(r"^([ \t]{0,3})(#{1,6})[ \t]+gotchas\b.*$", re.IGNORECASE | re.MULTILINE)
+# A placeholder body meaning "there are none yet" -- replaced rather than appended to.
+NONE_KNOWN = re.compile(r"^\s*(none known|none|n/a)\.?\s*$", re.IGNORECASE)
+# Sections a Gotchas block should precede when one has to be created from scratch.
+FALLBACK_ANCHORS = ("## Keywords", "## Usage Examples", "## References", "## Anti-goals")
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_correction(skill_dir: Path, text: str) -> list[str]:
+    """Write a user correction to EVOLUTION.md and the SKILL.md Gotchas section.
+
+    Verbatim on purpose. The wording a user reaches for when something is wrong
+    carries detail a paraphrase drops, and this runs unattended -- rewriting it
+    into the wrong-assumption/real-behavior house style is a judgment call for
+    whoever next edits the skill, not for this script.
+
+    Args:
+        skill_dir: The skill's root (the directory holding SKILL.md).
+        text: The correction, as the user phrased it.
+
+    Returns:
+        Human-readable lines describing what changed, for printing.
+
+    Raises:
+        ValueError: If the text is blank or SKILL.md is missing.
+    """
+    text = " ".join(text.split())
+    if not text:
+        raise ValueError("correction text is empty")
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise ValueError(f"SKILL.md not found in {skill_dir}")
+
+    stamp = _utc_stamp()
+    done: list[str] = []
+
+    # 1. EVOLUTION.md -- the audit trail. Append-only, never rewritten.
+    evolution = skill_dir / "EVOLUTION.md"
+    if not evolution.exists():
+        evolution.write_text(
+            "# Evolution log\n\nAppended automatically by scripts/run_evals.py "
+            "(and scripts/evolve.py) when a check fails. Each entry is the raw "
+            "evidence for a fix/regenerate step.\n\n",
+            encoding="utf-8",
+        )
+    with evolution.open("a", encoding="utf-8") as fh:
+        fh.write(
+            f"## {stamp} — correction from use\n\n"
+            f"Reported while using the skill, not caught by any automated check.\n\n"
+            f"> {text}\n\n"
+            f"Added to the SKILL.md `## Gotchas` section.\n\n"
+        )
+    done.append(f"EVOLUTION.md  <- correction recorded ({stamp})")
+
+    # 2. SKILL.md ## Gotchas -- the part the agent actually reads on the next run.
+    content = skill_md.read_text(encoding="utf-8")
+    bullet = f"- {text}"
+    match = GOTCHAS_HEADING.search(content)
+
+    if match:
+        level = len(match.group(2))
+        body_start = match.end()
+        # The section runs to the next heading at the same level or higher.
+        following = re.compile(rf"^[ \t]{{0,3}}#{{1,{level}}}[ \t]+", re.MULTILINE)
+        nxt = following.search(content, body_start)
+        body_end = nxt.start() if nxt else len(content)
+        body = content[body_start:body_end]
+
+        if all(NONE_KNOWN.match(ln) or not ln.strip() for ln in body.splitlines()):
+            new_body = f"\n\n{bullet}\n\n"          # replace the placeholder
+            note = "replaced 'None known'"
+        else:
+            new_body = body.rstrip("\n") + f"\n{bullet}\n\n"
+            note = "appended"
+        content = content[:body_start] + new_body + content[body_end:]
+    else:
+        section = f"## Gotchas\n\n{bullet}\n\n"
+        anchor = next((a for a in FALLBACK_ANCHORS if f"\n{a}" in content), None)
+        if anchor:
+            content = content.replace(f"\n{anchor}", f"\n{section}{anchor}", 1)
+        else:
+            content = content.rstrip("\n") + f"\n\n{section}"
+        note = "created the section"
+
+    skill_md.write_text(content, encoding="utf-8")
+    done.append(f"SKILL.md      <- ## Gotchas ({note})")
+    return done
 
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
     root = Path(__file__).resolve().parent.parent
+
+    if "--correct" in args:
+        index = args.index("--correct")
+        text = " ".join(args[index + 1:])
+        if not text.strip():
+            print(
+                'usage: python3 scripts/evolve.py --correct "<what the skill got wrong>"',
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            for line in record_correction(root, text):
+                print(line)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print("\nnext: run scripts/evolve.py to re-verify, and reword the entry in the")
+        print("house style (wrong assumption -> real behavior) next time you edit the skill")
+        return 0
+
     judge = ["--judge"] if "--judge" in args else []
 
     steps = [

--- a/references/pipeline-phases.md
+++ b/references/pipeline-phases.md
@@ -1084,6 +1084,23 @@ Sources, in order:
 3. Anything the user said in the form "oh, and you have to..." — those are gotchas
    the user did not think to put in the spec because they live in muscle memory.
 
+Sources 1 and 2 are yours to find. Source 3 mostly **will not arrive at creation
+time**, and you should not stall trying to extract it. A person cannot describe a
+process they run from muscle memory — that is the premise this whole factory is
+built on. What they can do is recognize a wrong output the moment they see one.
+
+So ship the skill with the gotchas you have, and tell the user how to add the rest
+as they surface:
+
+```bash
+python3 scripts/evolve.py --correct "the West region files late, so Friday exports are short"
+```
+
+That writes the sentence verbatim to `EVOLUTION.md` and appends it to `## Gotchas`,
+so the next run already knows. A skill's gotchas should grow over its life; an
+empty section on day one is honest, and a section that never grows means nobody
+ever told it anything.
+
 Format each entry as the wrong assumption followed by the real behavior:
 
 ```markdown

--- a/scripts/evolve_template.py
+++ b/scripts/evolve_template.py
@@ -5,9 +5,10 @@ Evolve loop shipped inside every generated skill as scripts/evolve.py.
 One command that closes the maintenance loop from the skill's own root:
 
     python3 scripts/evolve.py            # detect -> record -> re-verify
-    python3 scripts/evolve.py --judge    # also grade llm-judge criteria (needs ANTHROPIC_API_KEY)
+    python3 scripts/evolve.py --judge    # also grade llm-judge criteria
+    python3 scripts/evolve.py --correct "<what the skill got wrong>"
 
-Steps:
+Steps (default mode):
   1. staleness_check --check-deps --check-drift --record
      (review-interval, dependency health, schema drift; failures append raw
      evidence to EVOLUTION.md)
@@ -15,21 +16,150 @@ Steps:
      (runs the skill on its golden inputs; command checks + baseline regression
      gate + optional pinned judge; failures append raw evidence to EVOLUTION.md)
 
+`--correct` is a different kind of input, and the most valuable one this loop
+takes. Steps 1 and 2 catch what a machine can check: dates, reachability, output
+drift. They cannot catch the class of knowledge that only exists in someone's
+head -- the region that files late, the code that means something local, the
+month the process runs differently.
+
+That knowledge is not obtainable by asking up front. People cannot articulate a
+workflow they run from muscle memory, which is why this factory reads artifacts
+instead of interviewing. But the same person who could not describe the rule will
+recognize its violation instantly, the moment the skill produces something wrong.
+`--correct` is the capture point for that moment: it takes the sentence they would
+have said out loud, writes it verbatim to EVOLUTION.md as evidence, and adds it to
+the skill's `## Gotchas` so the next run already knows.
+
 Exit codes:
-    0 - fresh and green
+    0 - fresh and green (or: correction recorded)
     1 - one or more steps failed; EVOLUTION.md holds the evidence
+    2 - bad usage
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+GOTCHAS_HEADING = re.compile(r"^([ \t]{0,3})(#{1,6})[ \t]+gotchas\b.*$", re.IGNORECASE | re.MULTILINE)
+# A placeholder body meaning "there are none yet" -- replaced rather than appended to.
+NONE_KNOWN = re.compile(r"^\s*(none known|none|n/a)\.?\s*$", re.IGNORECASE)
+# Sections a Gotchas block should precede when one has to be created from scratch.
+FALLBACK_ANCHORS = ("## Keywords", "## Usage Examples", "## References", "## Anti-goals")
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_correction(skill_dir: Path, text: str) -> list[str]:
+    """Write a user correction to EVOLUTION.md and the SKILL.md Gotchas section.
+
+    Verbatim on purpose. The wording a user reaches for when something is wrong
+    carries detail a paraphrase drops, and this runs unattended -- rewriting it
+    into the wrong-assumption/real-behavior house style is a judgment call for
+    whoever next edits the skill, not for this script.
+
+    Args:
+        skill_dir: The skill's root (the directory holding SKILL.md).
+        text: The correction, as the user phrased it.
+
+    Returns:
+        Human-readable lines describing what changed, for printing.
+
+    Raises:
+        ValueError: If the text is blank or SKILL.md is missing.
+    """
+    text = " ".join(text.split())
+    if not text:
+        raise ValueError("correction text is empty")
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise ValueError(f"SKILL.md not found in {skill_dir}")
+
+    stamp = _utc_stamp()
+    done: list[str] = []
+
+    # 1. EVOLUTION.md -- the audit trail. Append-only, never rewritten.
+    evolution = skill_dir / "EVOLUTION.md"
+    if not evolution.exists():
+        evolution.write_text(
+            "# Evolution log\n\nAppended automatically by scripts/run_evals.py "
+            "(and scripts/evolve.py) when a check fails. Each entry is the raw "
+            "evidence for a fix/regenerate step.\n\n",
+            encoding="utf-8",
+        )
+    with evolution.open("a", encoding="utf-8") as fh:
+        fh.write(
+            f"## {stamp} — correction from use\n\n"
+            f"Reported while using the skill, not caught by any automated check.\n\n"
+            f"> {text}\n\n"
+            f"Added to the SKILL.md `## Gotchas` section.\n\n"
+        )
+    done.append(f"EVOLUTION.md  <- correction recorded ({stamp})")
+
+    # 2. SKILL.md ## Gotchas -- the part the agent actually reads on the next run.
+    content = skill_md.read_text(encoding="utf-8")
+    bullet = f"- {text}"
+    match = GOTCHAS_HEADING.search(content)
+
+    if match:
+        level = len(match.group(2))
+        body_start = match.end()
+        # The section runs to the next heading at the same level or higher.
+        following = re.compile(rf"^[ \t]{{0,3}}#{{1,{level}}}[ \t]+", re.MULTILINE)
+        nxt = following.search(content, body_start)
+        body_end = nxt.start() if nxt else len(content)
+        body = content[body_start:body_end]
+
+        if all(NONE_KNOWN.match(ln) or not ln.strip() for ln in body.splitlines()):
+            new_body = f"\n\n{bullet}\n\n"          # replace the placeholder
+            note = "replaced 'None known'"
+        else:
+            new_body = body.rstrip("\n") + f"\n{bullet}\n\n"
+            note = "appended"
+        content = content[:body_start] + new_body + content[body_end:]
+    else:
+        section = f"## Gotchas\n\n{bullet}\n\n"
+        anchor = next((a for a in FALLBACK_ANCHORS if f"\n{a}" in content), None)
+        if anchor:
+            content = content.replace(f"\n{anchor}", f"\n{section}{anchor}", 1)
+        else:
+            content = content.rstrip("\n") + f"\n\n{section}"
+        note = "created the section"
+
+    skill_md.write_text(content, encoding="utf-8")
+    done.append(f"SKILL.md      <- ## Gotchas ({note})")
+    return done
 
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
     root = Path(__file__).resolve().parent.parent
+
+    if "--correct" in args:
+        index = args.index("--correct")
+        text = " ".join(args[index + 1:])
+        if not text.strip():
+            print(
+                'usage: python3 scripts/evolve.py --correct "<what the skill got wrong>"',
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            for line in record_correction(root, text):
+                print(line)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print("\nnext: run scripts/evolve.py to re-verify, and reword the entry in the")
+        print("house style (wrong assumption -> real behavior) next time you edit the skill")
+        return 0
+
     judge = ["--judge"] if "--judge" in args else []
 
     steps = [

--- a/scripts/tests/test_evolve.py
+++ b/scripts/tests/test_evolve.py
@@ -72,5 +72,98 @@ class EvolveLoopTest(unittest.TestCase):
             self.assertIn("```json", evolution.read_text(encoding="utf-8"))
 
 
+class CorrectionCaptureTest(unittest.TestCase):
+    """`--correct` is the only path by which knowledge no check can derive gets in."""
+
+    CORRECTION = "the West region files late, so Friday exports are short"
+
+    def _skill(self, tmp: Path, body: str) -> Path:
+        skill = tmp / "demo"
+        (skill / "scripts").mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            f"---\nname: demo\ndescription: Demo.\n---\n# /demo\n\n{body}\n",
+            encoding="utf-8",
+        )
+        shutil.copy(ROOT / "scripts" / "evolve_template.py", skill / "scripts" / "evolve.py")
+        return skill
+
+    def _run(self, skill: Path, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "scripts/evolve.py", *args],
+            cwd=skill, capture_output=True, text=True, timeout=60,
+        )
+
+    def _gotchas(self, skill: Path) -> str:
+        text = (skill / "SKILL.md").read_text(encoding="utf-8")
+        return text[text.index("## Gotchas"):]
+
+    def test_replaces_none_known_placeholder(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "## Gotchas\n\nNone known.\n\n## Keywords\n\nfoo")
+            proc = self._run(skill, "--correct", self.CORRECTION)
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            self.assertEqual(
+                self._gotchas(skill),
+                f"## Gotchas\n\n- {self.CORRECTION}\n\n## Keywords\n\nfoo\n",
+            )
+
+    def test_appends_below_existing_gotchas(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "## Gotchas\n\n- Already known.\n\n## Keywords\n\nfoo")
+            self._run(skill, "--correct", self.CORRECTION)
+            self.assertEqual(
+                self._gotchas(skill),
+                f"## Gotchas\n\n- Already known.\n- {self.CORRECTION}\n\n## Keywords\n\nfoo\n",
+            )
+
+    def test_creates_the_section_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "Body.\n\n## Keywords\n\nfoo")
+            self._run(skill, "--correct", self.CORRECTION)
+            self.assertEqual(
+                self._gotchas(skill),
+                f"## Gotchas\n\n- {self.CORRECTION}\n\n## Keywords\n\nfoo\n",
+            )
+
+    def test_creates_the_section_with_no_anchor_to_precede(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "Body only.")
+            self._run(skill, "--correct", self.CORRECTION)
+            self.assertEqual(self._gotchas(skill), f"## Gotchas\n\n- {self.CORRECTION}\n\n")
+
+    def test_records_verbatim_evidence_in_evolution(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "## Gotchas\n\nNone known.")
+            self._run(skill, "--correct", self.CORRECTION)
+            log = (skill / "EVOLUTION.md").read_text(encoding="utf-8")
+            self.assertIn("correction from use", log)
+            self.assertIn(f"> {self.CORRECTION}", log)
+
+    def test_repeated_corrections_all_survive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "## Gotchas\n\nNone known.\n\n## Keywords\n\nfoo")
+            self._run(skill, "--correct", "first thing")
+            self._run(skill, "--correct", "second thing")
+            gotchas = self._gotchas(skill)
+            self.assertIn("- first thing", gotchas)
+            self.assertIn("- second thing", gotchas)
+            self.assertEqual((skill / "EVOLUTION.md").read_text().count("correction from use"), 2)
+
+    def test_blank_correction_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "## Gotchas\n\nNone known.")
+            proc = self._run(skill, "--correct", "   ")
+            self.assertEqual(proc.returncode, 2)
+            self.assertNotIn("- ", self._gotchas(skill))
+            self.assertFalse((skill / "EVOLUTION.md").exists())
+
+    def test_does_not_run_the_verification_steps(self):
+        """--correct is a capture command; it must not trigger evals or staleness."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = self._skill(Path(tmp), "## Gotchas\n\nNone known.")
+            proc = self._run(skill, "--correct", self.CORRECTION)
+            self.assertNotIn("== evolve:", proc.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -31,7 +31,7 @@ MAX_BODY_LINES_WARNING = 500
 # Heading that must carry the skill's environment-specific facts. Warning-level:
 # the section is required doctrine, but a missing heading should not block delivery
 # of an otherwise-working skill.
-GOTCHAS_HEADING_PATTERN = re.compile(r"^\s{0,3}#{1,6}\s+gotchas\b", re.IGNORECASE | re.MULTILINE)
+GOTCHAS_HEADING_PATTERN = re.compile(r"^[ \t]{0,3}#{1,6}[ \t]+gotchas\b", re.IGNORECASE | re.MULTILINE)
 
 # --- Run-vs-read labeling ---
 #


### PR DESCRIPTION
The evolve loop could only learn from what a machine can check: review dates, dependency reachability, output drift against a baseline. Nothing could get a correction from the person *using* the skill into the skill.

## Why this is the gap that matters

The factory's whole premise is that people cannot write a specification for work they do from muscle memory — which is why it reads artifacts instead of interviewing. But the same reasoning applies to gotchas, and there the factory stopped short.

Of the three sources the docs list for `## Gotchas`:

| Source | Obtainable? |
|---|---|
| Phase 1 API research quirks | Machine-derivable ✓ |
| Corrections made during Phase 5 verification | Machine-derivable ✓ |
| *"Anything the user said in the form 'oh, and you have to...'"* | **Requires the human to volunteer knowledge they can't retrieve on demand** ✗ |

The West region files late. Nobody says that until they see a report that's wrong.

I checked what fed `EVOLUTION.md` before this PR: staleness dates, dependency health, eval-rollout failures. Three automated sources, no human path. The richest source of gotchas — someone correcting the skill in month three of real use — evaporated into a chat log.

So: stop asking, and capture the correction at the only moment the knowledge is accessible.

```bash
python3 scripts/evolve.py --correct "the West region files late, so Friday exports are short"
```

Writes the sentence **verbatim** to `EVOLUTION.md` as timestamped evidence, and appends it to `## Gotchas` so the next run already knows.

Verbatim on purpose: the wording someone reaches for when something is wrong carries detail a paraphrase drops, and rewriting it into the house style (wrong assumption → real behavior) is a judgment call for whoever next edits the skill, not for a script running unattended. The script does the deterministic part; the agent does the judgment.

## Section handling

Four states, all tested:

| State | Behavior |
|---|---|
| `## Gotchas` says `None known` | Replaces the placeholder |
| `## Gotchas` has entries | Appends below them |
| No `## Gotchas` | Creates it before Keywords / Usage Examples / References / Anti-goals |
| No section, no anchor | Appends at end of file |

`--correct` never triggers the staleness or eval steps — it's a capture command, not a verification run.

## A bug this surfaced

`validate.py` has carried this since the Gotchas check shipped: `\s{0,3}` before a heading **matches newlines**, so a section-boundary search consumes blank lines. In the new code it produced stray whitespace; in `validate.py` it made the heading match sloppier than intended. Both patterns now match literal indentation only (`[ \t]{0,3}`).

## Docs

The Phase 5 gotchas guidance now says outright that source 3 will usually **not** arrive at creation time and that stalling to extract it is wrong — ship with what you have and tell the user how to add the rest. SKILL.md instructs the agent to mention `--correct` at handover. README gains a "Corrections from use" section.

> A skill's gotchas should grow over its life. An empty section on day one is honest; a section that never grows means nobody ever told it anything.

## Verification

- **312 tests pass** (8 new: four section states, verbatim evidence, repeated corrections, blank-input rejection, and that it skips the verification steps)
- `ruff check` clean; SKILL.md still 487 body lines, no quality warnings
- `evolve.py` re-vendored to all three examples (parity test enforces this)
- Smoke-tested end-to-end on a real copy of `weekly-crm-report`: the correction appended correctly below its three existing multi-line gotchas, and the skill still validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)