### PR TITLE
fix: Cursor missing from install.sh, and CONTRIBUTING's incomplete checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,19 +51,25 @@ files — change them together or CI's parity tests will catch the drift:
 1. **`scripts/platforms.py`** — add the platform tuple (name, user-level
    install path, project-level install path, detection directory). This is
    the single source of truth the registry and installers read.
-2. **`install.sh` and `install.ps1`** — add the detection/install branch to
-   both (bash and PowerShell must stay in lockstep).
-3. **`scripts/install-template.sh` and `scripts/install-template.ps1`** —
-   the installer template bundled into generated skills; mirror the same
-   branch there.
-4. **Docs** — add the platform to the tier table in `SKILL.md` and
-   `references/cross-platform-guide.md`. If the platform needs a format
-   adapter (not native SKILL.md), document the transformation in the Tier 2
-   section.
-5. **Platform count** — the number of supported platforms is stated in
-   `README.md`, `SKILL.md`, and `references/cross-platform-guide.md`. Bump
-   it in **all three** in the same PR (and remind a maintainer to update the
-   GitHub repo description).
+2. **Four shell pairs.** Every one enumerates platforms independently, and
+   each `.sh`/`.ps1` pair is parity-gated by `test_install_parity.py`:
+   - `install.sh` / `install.ps1` — the repo's own self-installer
+   - `scripts/install-template.sh` / `.ps1` — bundled into generated skills
+   - `scripts/install-skill.sh` / `.ps1` — the universal skill installer
+   - `scripts/bootstrap.sh` / `.ps1` — the `curl | sh` one-liner
+3. **Docs** — add the platform to the tier table in
+   `references/cross-platform-guide.md` (and `docs/INSTALL.md` if it needs a
+   per-tool install path). If the platform needs a format adapter (not native
+   SKILL.md), document the transformation in the Tier 2 section.
+4. **Platform count** — the total is stated in **six** files:
+   `README.md`, `SKILL.md`, `references/cross-platform-guide.md`,
+   `docs/INSTALL.md`, `references/pipeline-phases.md`, and `docs/index.html`.
+   Bump every one in the same PR, and remind a maintainer to update the GitHub
+   repo description. Find them all with:
+
+   ```bash
+   grep -rn "17 platform\|17 tool" --include="*.md" --include="*.html" .
+   ```
 
 Then verify:
 
@@ -73,6 +79,9 @@ uv run pytest scripts/tests/test_platforms.py scripts/tests/test_install_parity.
 
 `test_platforms.py` cross-checks `platforms.py` against the shell installers,
 so a partial addition fails loudly.
+
+**Nothing checks the docs.** Steps 3 and 4 are unenforced — a stale tier table
+or a count that still says the old number passes CI. Grep before you push.
 
 ## A note on eval specs
 

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,7 @@ $HOME/.cline|$HOME/.cline/skills/$SKILL_NAME|Cline
 $HOME/.roo|$HOME/.roo/skills/$SKILL_NAME|Roo Code
 $HOME/.kilocode|$HOME/.kilocode/skills/$SKILL_NAME|Kilo Code
 $HOME/.factory|$HOME/.factory/skills/$SKILL_NAME|Factory Droid
+$HOME/.cursor|$HOME/.cursor/rules/$SKILL_NAME|Cursor
 $HOME/.config/goose|$HOME/.config/goose/skills/$SKILL_NAME|Goose
 $HOME/.config/opencode|$HOME/.config/opencode/skills/$SKILL_NAME|OpenCode
 PLATFORMS

--- a/scripts/tests/test_install_parity.py
+++ b/scripts/tests/test_install_parity.py
@@ -91,6 +91,37 @@ def _parse_install_template_ps1(text: str) -> tuple[list[str], dict[str, str], d
     return supported, project, user
 
 
+# --- root install.sh / install.ps1 parsers ---------------------------------
+#
+# The repo's OWN self-installers, as opposed to the templates that ship into
+# generated skills. They were the one shell pair nothing compared, which is how
+# Cursor came to be listed in install.ps1 and missing from install.sh: `--all`
+# installed for Cursor on Windows and silently skipped it everywhere else.
+
+_ROOT_SH_ENTRY = re.compile(r'^\$HOME/(\S+?)\|\$HOME/(\S+?)/\$SKILL_NAME\|(.+)$')
+_ROOT_PS1_ENTRY = re.compile(
+    r'DetectDir\s*=\s*"([^"]+)"\s*;\s*InstallPath\s*=\s*"([^"]+)\\\$SkillName"\s*;\s*Display\s*=\s*"([^"]+)"'
+)
+
+
+def _parse_root_install_sh(text: str) -> dict[str, tuple[str, str]]:
+    """Display name -> (detection dir, install dir), from the heredoc table."""
+    out: dict[str, tuple[str, str]] = {}
+    for line in text.splitlines():
+        m = _ROOT_SH_ENTRY.match(line.strip())
+        if m:
+            out[m.group(3).strip()] = (m.group(1), m.group(2))
+    return out
+
+
+def _parse_root_install_ps1(text: str) -> dict[str, tuple[str, str]]:
+    """Same shape from the PowerShell hashtable list, backslashes normalised."""
+    out: dict[str, tuple[str, str]] = {}
+    for detect, install, display in _ROOT_PS1_ENTRY.findall(text):
+        out[display.strip()] = (detect.replace("\\", "/"), install.replace("\\", "/"))
+    return out
+
+
 # --- bootstrap.sh / .ps1 parsers -------------------------------------------
 
 _SH_BOOTSTRAP_DETECT = re.compile(r'platforms="\$platforms\s+([\w-]+)"')
@@ -209,12 +240,48 @@ class BootstrapParityTest(unittest.TestCase):
     def test_bootstrap_sh_subset_of_ps1(self) -> None:
         """Stronger regression gate: bootstrap.sh's detected platforms must all
         be a subset of bootstrap.ps1's. New drift where bootstrap.sh gains a
-        platform that .ps1 lacks would fail here even while the known cursor
-        finding is still xfail above."""
+        platform that .ps1 lacks would fail here."""
         self.assertTrue(
             self.sh_plats.issubset(self.ps1_plats),
             f"bootstrap.sh detects platforms .ps1 does not: {self.sh_plats - self.ps1_plats}",
         )
+
+
+class RootInstallerParityTest(unittest.TestCase):
+    """The repo's own install.sh / install.ps1 must offer the same platforms.
+
+    Every other shell pair in the repo was already compared; this one was not,
+    and it drifted. `--all` is the user-visible symptom: a platform present in
+    only one script is installed on one OS and silently skipped on the other.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sh = _parse_root_install_sh((ROOT / "install.sh").read_text(encoding="utf-8"))
+        cls.ps1 = _parse_root_install_ps1((ROOT / "install.ps1").read_text(encoding="utf-8"))
+
+    def test_parsers_found_entries(self) -> None:
+        """Guard the regexes: a table reformat must fail loudly, not silently
+        compare two empty dicts and pass."""
+        self.assertGreaterEqual(len(self.sh), 10, "install.sh table did not parse")
+        self.assertGreaterEqual(len(self.ps1), 10, "install.ps1 table did not parse")
+
+    def test_same_platform_set(self) -> None:
+        self.assertEqual(
+            set(self.sh),
+            set(self.ps1),
+            "install.sh and install.ps1 offer different platforms for --all",
+        )
+
+    def test_paths_match(self) -> None:
+        for display, sh_paths in self.sh.items():
+            with self.subTest(platform=display):
+                self.assertEqual(
+                    sh_paths,
+                    self.ps1.get(display),
+                    f"{display}: detection or install path drifted between "
+                    f"install.sh and install.ps1",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two real bugs, both found by running the factory end to end against its own repo and grading the output. The generated skill audited every platform enumeration in the tree — which is how it found things no existing test covers.

## 1. Cursor was missing from `install.sh`

`install.ps1` listed it; `install.sh` did not.

**User-visible symptom:** `--all` installed the skill for Cursor on Windows and silently skipped it on macOS and Linux.

`install.ps1` and `scripts/platforms.py` agree the path is `~/.cursor/rules`, so `install.sh` was the outlier. Both tables now list 11 platforms.

### Why it survived

Every *other* shell pair in the repo is parity-gated. The repo's **own** `install.sh` / `install.ps1` pair was never compared:

| Pair | Covered before? |
|---|---|
| `scripts/install-template.{sh,ps1}` | yes |
| `scripts/install-skill.{sh,ps1}` | yes |
| `scripts/bootstrap.{sh,ps1}` | yes |
| **`install.sh` / `install.ps1`** | **no** |

The two scripts a contributor is most likely to edit by hand were the blind spot.

Adds `RootInstallerParityTest`: same platform set, same detection and install paths, plus a guard asserting the regexes actually matched rows — so a table reformat fails loudly instead of silently comparing two empty dicts and passing.

**Verified the test catches the bug.** Reintroducing it fails with:

```
AssertionError: Items in the second set but not the first:
'Cursor' : install.sh and install.ps1 offer different platforms for --all
```

## 2. `CONTRIBUTING.md`'s checklist was wrong in two ways

**It named one shell pair when there are four.** It omitted `scripts/install-skill.{sh,ps1}` and `scripts/bootstrap.{sh,ps1}` — both hard-gated by `test_install_parity.py`. Following the documented process to the letter still landed a red build.

**It said the platform count lives in three files.** It's in six: `README.md`, `SKILL.md`, `references/cross-platform-guide.md`, `docs/INSTALL.md`, `references/pipeline-phases.md`, `docs/index.html`.

Rewritten with the verified list, a `grep` that finds every count, and an explicit note that the doc steps are **unenforced** — no test checks a stale tier table or a count that still says the old number.

Also drops a stale docstring in `test_install_parity.py` referring to an `xfail` that no longer exists.

## Verification

- **315 tests pass** (3 new), `ruff check` clean
- `sh -n install.sh` — still valid POSIX
- `security_scan.py ./` — 0 high-severity findings
- New test proven to fail when the bug is reintroduced, then pass when fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)