### PR TITLE
Bump CI actions off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run ruff
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.1.0
         with:
           args: "check --target-version py310"
 
@@ -23,17 +23,17 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Run test suite
         run: uv run --with pytest pytest scripts/tests/ -q
@@ -94,13 +94,13 @@ jobs:
             # portable and does run on Windows.
             pytest_args: "scripts/tests/ -q --ignore=scripts/tests/test_run_evals.py"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Run test suite
         run: uv run --with pytest pytest ${{ matrix.pytest_args }}
 
@@ -109,7 +109,7 @@ jobs:
     # unnoticed (the headline claim includes Windows tools).
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Parse-check PowerShell installers
         shell: pwsh
         run: |


### PR DESCRIPTION
Every CI job emitted a Node 20 deprecation annotation because `checkout`, `setup-python`, `setup-uv`, and `ruff-action` were pinned to majors that predate the Node 24 migration.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `v4` | `v7` |
| `actions/setup-python` | `v5` | `v7` |
| `astral-sh/setup-uv` | `v5` | `v10.0.1` |
| `astral-sh/ruff-action` | `v3` | `v4.1.0` |

`setup-uv` and `ruff-action` are pinned to exact versions rather than a major tag: `setup-uv` stopped publishing major and minor tags at v8 to reduce supply-chain exposure, and `ruff-action` did the same at v4, so `@v10` and `@v4` do not resolve.

None of the removed or changed inputs are used here. `setup-python` v7 drops `pip-install`, `setup-uv` v7 drops `server-url`, and `checkout` v7 blocks fork checkouts for `pull_request_target`/`workflow_run`, which this workflow does not trigger on.

This PR exists to run CI against the new pins — the workflow only triggers on pushes to `main` and PRs into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ET5GivdWTbXb3jQgnU7Mc