### PR TITLE
Tell contributors how to repair verification evidence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,41 @@ python3 scripts/check_pipeline.py <skill-dir>
 
 # Security scan
 python3 scripts/security_scan.py <skill-dir>
+
+# Run every gate a skill package must pass (spec, security, pipeline,
+# eval schema, Semantic Recon contracts)
+python3 scripts/skill_graph.py run <skill-dir>
+
+# Check that changed skills carry current verification evidence,
+# exactly as CI does
+python3 scripts/check_verification.py --base origin/main
 ```
+
+## Changing a bundled skill
+
+Anything under `references/examples/` is a real skill package, so CI holds it
+to the same gates a user's skill must pass. Two of those catch contributors
+out.
+
+**Semantic Recon contracts.** A skill whose `discovery.json` sets
+`data_interfaces.applies` must also declare `semantic_recon.sources` and ship
+the contract it names (`.contract_id` plus `code/contract_health.py`).
+`skill_graph.py run` fails otherwise, and its error carries the repair.
+
+**Verification evidence binds to a commit.** `VERIFICATION.md` records the
+commit that existed when it was generated, and the gate accepts a follow-up
+commit whose diff within the skill is *exactly* `{VERIFICATION.md}`. So a
+combined commit is rejected even when the evidence itself is current, and
+landing a change takes three steps in this order:
+
+1. Commit the behavior change. Include the `## Verification` link that
+   `generate_verification.py` appends to `README.md` — it must land here, not
+   in step 3.
+2. `python3 scripts/generate_verification.py <skill-dir>`
+3. Commit `VERIFICATION.md` on its own.
+
+`check_verification.py` prints this sequence whenever it fails, so you do not
+need to memorize it.
 
 ## Conventions
 

--- a/scripts/check_verification.py
+++ b/scripts/check_verification.py
@@ -10,6 +10,40 @@ from pathlib import Path
 
 from generate_verification import verification_errors
 
+REGENERATE = "regenerate with python3 scripts/generate_verification.py {skill}"
+REPAIRS = {
+    "VERIFICATION.md is missing": REGENERATE,
+    "VERIFICATION.md has no machine-readable evidence state": REGENERATE,
+    "VERIFICATION.md has malformed evidence state": REGENERATE,
+    "verification version does not match SKILL.md": REGENERATE,
+    "verification is stale": REGENERATE,
+    "verification commit does not match": REGENERATE,
+    "verification records failed gates or evals": (
+        "fix the failing gate or eval first with "
+        "python3 scripts/skill_graph.py run {skill}, then regenerate"
+    ),
+}
+SEQUENCE = """
+A report binds to the commit it records, so landing a skill change takes
+three steps in this order:
+
+  1. Commit the behavior change. Include the "## Verification" link that
+     generate_verification.py appends to README.md -- it must land here,
+     not in step 3.
+  2. python3 scripts/generate_verification.py <skill-dir>
+  3. Commit VERIFICATION.md on its own. The gate accepts a follow-up commit
+     whose diff within the skill is exactly {VERIFICATION.md}, so a combined
+     commit is rejected even when the evidence itself is current.
+"""
+
+
+def repair_for(error: str, skill: str) -> str:
+    """Return the repair line for one verification error."""
+    for prefix, repair in REPAIRS.items():
+        if error.startswith(prefix):
+            return repair.format(skill=skill)
+    return REGENERATE.format(skill=skill)
+
 
 def changed_skill_dirs(base: str, head: str = "HEAD") -> list[Path]:
     """Return unique skill roots affected between two Git revisions."""
@@ -41,12 +75,17 @@ def main(argv: list[str] | None = None) -> int:
     for skill in skills:
         errors = verification_errors(skill)
         if errors:
-            failures.extend(f"{skill}: {error}" for error in errors)
+            failures.extend(f"- {skill}: {error}" for error in errors)
+            # One repair usually covers every error on a skill; list each
+            # distinct repair once rather than after every line.
+            repairs = dict.fromkeys(repair_for(error, str(skill)) for error in errors)
+            failures.extend(f"  repair: {repair}" for repair in repairs)
         else:
             print(f"PASS {skill}: verification evidence is current")
     if failures:
         print("Verification gate failed:", file=sys.stderr)
-        print("\n".join(f"- {failure}" for failure in failures), file=sys.stderr)
+        print("\n".join(failures), file=sys.stderr)
+        print(SEQUENCE, file=sys.stderr)
         return 1
     print(f"Verification gate passed for {len(skills)} changed skill(s).")
     return 0

--- a/scripts/tests/test_check_verification.py
+++ b/scripts/tests/test_check_verification.py
@@ -4,8 +4,38 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from check_verification import changed_skill_dirs  # noqa: E402
+import check_verification  # noqa: E402
+from check_verification import changed_skill_dirs, repair_for  # noqa: E402
 
 
 def test_changed_skill_dirs_returns_no_skills_when_diff_is_empty() -> None:
     assert changed_skill_dirs("HEAD", "HEAD") == []
+
+
+def test_repair_names_the_regenerate_command_for_stale_evidence() -> None:
+    repair = repair_for("verification is stale: SKILL.md, scripts, or evals changed", "skills/foo")
+    assert "generate_verification.py skills/foo" in repair
+
+
+def test_repair_sends_a_failed_gate_to_the_graph_runner_first() -> None:
+    repair = repair_for("verification records failed gates or evals", "skills/foo")
+    assert "skill_graph.py run skills/foo" in repair
+    assert "fix the failing gate or eval first" in repair
+
+
+def test_repair_falls_back_to_regenerating_for_an_unrecognized_error() -> None:
+    assert "generate_verification.py skills/foo" in repair_for("something new", "skills/foo")
+
+
+def test_failure_output_carries_a_repair_line_and_the_commit_sequence(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(check_verification, "changed_skill_dirs", lambda base: [Path("skills/foo")])
+    monkeypatch.setattr(check_verification, "verification_errors", lambda skill: ["VERIFICATION.md is missing"])
+
+    assert check_verification.main(["--base", "HEAD~1"]) == 1
+
+    err = capsys.readouterr().err
+    assert "skills/foo: VERIFICATION.md is missing" in err
+    assert "repair: regenerate with python3" in err
+    # The report-only follow-up rule is the part a contributor cannot guess.
+    assert "exactly {VERIFICATION.md}" in err
+    assert "not in step 3" in err


### PR DESCRIPTION
Closes #38.

`check_verification.py` reported what was wrong and nothing about how to fix it, while `skill_graph.py` has carried a `repair:` line on every error all along.

The gap has a cost: three bundled examples had never carried a `VERIFICATION.md`, so the gate failed on every commit touching them, and the fix is not guessable — `_is_report_only_followup` accepts only a follow-up commit whose diff within the skill is exactly `{VERIFICATION.md}`, so the obvious single combined commit is rejected even when the evidence is current.

## Changes

**`scripts/check_verification.py`** — failures now carry a per-skill `repair:` line (deduplicated, since one repair usually covers every error on a skill) and print the three-step commit sequence. Failed gates or evals route to `skill_graph.py run` first rather than straight to a regenerate that would just fail again.

Sample output:

```
Verification gate failed:
- references/examples/stock-analyzer: verification is stale: SKILL.md, scripts, or evals changed
- references/examples/stock-analyzer: verification commit does not match current Git commit
  repair: regenerate with python3 scripts/generate_verification.py references/examples/stock-analyzer

A report binds to the commit it records, so landing a skill change takes
three steps in this order:
  ...
```

**`CONTRIBUTING.md`** — adds `skill_graph.py` and `check_verification.py` to "Local checks" (the two gates most likely to fail a PR were the two missing), plus a "Changing a bundled skill" section covering the Semantic Recon contract requirement and the commit sequence.

**`scripts/tests/test_check_verification.py`** — four tests covering the repair mapping, the fallback for unrecognized errors, and the presence of both the repair line and the report-only rule in failure output.

## Verification

610 passed (was 606), ruff clean, public-docs audit PASS. No skill package changed, so no verification evidence needed regenerating.

The `README.md` side-effect detail in step 1 is documented from experience — it cost an amend during the CI repair that surfaced this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ET5GivdWTbXb3jQgnU7Mc